### PR TITLE
Fix lawn mower activity stuck on "docked" during active sessions

### DIFF
--- a/custom_components/eufy_robomow/const.py
+++ b/custom_components/eufy_robomow/const.py
@@ -88,10 +88,14 @@ CUT_HEIGHT_STEP = 5  # mm
 # ── Activity state logic ──────────────────────────────────────────────────────
 # Confirmed via live DPS monitoring:
 #
-#  DP1 absent,  DP2 absent                    → DOCKED  (cold / never started)
-#  DP1=True,    DP2=False,  DP118=0           → MOWING
-#  DP1=True,    DP2=False,  DP118 5–99        → RETURNING (progress back to base)
-#  DP1=True,    DP2=False,  DP118=100         → DOCKED  (returned after session)
-#  DP1=True,    DP2=True                      → PAUSED
+#  DP1 absent/False                            → DOCKED  (no active session)
+#  DP1=True,    DP2=False,  DP118=0            → MOWING
+#  DP1=True,    DP2=False,  DP118 5–99         → RETURNING (progress back to base)
+#  DP1=True,    DP2=False,  DP118=100          → MOWING  (returned to charge mid-session; will resume)
+#  DP1=True,    DP2=True                       → PAUSED
+#
+# NOTE: A previous version mapped (DP1=True, DP118=100) to DOCKED, which caused
+# the entity to remain "docked" once the mower briefly returned for charging
+# during an active session (issue #1). DP1 is the authoritative session flag.
 #
 RETURNING_THRESHOLD = 5  # DP118 ≥ this value while DP1 active = RETURNING

--- a/custom_components/eufy_robomow/lawn_mower.py
+++ b/custom_components/eufy_robomow/lawn_mower.py
@@ -75,23 +75,27 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
         dps = self.coordinator.data
         dp1   = dps.get(DP_TASK_ACTIVE, False)
         dp2   = dps.get(DP_PAUSED,      False)
-        dp118 = dps.get(DP_PROGRESS,    100)
+        # Default 0 (not 100): when DP118 is missing while a session is active,
+        # we should not assume the mower has finished and is docked.
+        dp118 = dps.get(DP_PROGRESS,    0)
 
-        # Paused: task active but movement stopped
-        if dp1 and dp2:
-            return LawnMowerActivity.PAUSED
+        # DP1=True means a session is running (mowing / returning / interrupted
+        # for charging within an active session). Only DP1=False means the
+        # mower is truly idle / docked.
+        if dp1:
+            # Paused: session active but movement stopped
+            if dp2:
+                return LawnMowerActivity.PAUSED
 
-        if dp1 and not dp2:
-            # DP118=100 → task finished, mower is back in dock
-            if dp118 >= 100:
-                return LawnMowerActivity.DOCKED
             # DP118 climbing (5–99) → mower returning to base
-            if dp118 >= RETURNING_THRESHOLD:
+            if RETURNING_THRESHOLD <= dp118 < 100:
                 try:
                     return LawnMowerActivity.RETURNING
                 except AttributeError:
                     return LawnMowerActivity.MOWING
-            # DP118 near 0 → actively mowing
+
+            # DP118 near 0 (mowing) or 100 (returned to charge mid-session,
+            # will resume) → actively mowing
             return LawnMowerActivity.MOWING
 
         # DP1 absent or False → no active session → docked / idle


### PR DESCRIPTION
### Problem
Fixes #1. Reported by @sven-debug and confirmed by @phiwa99 / @Moater11: after starting the mower from Home Assistant the `lawn_mower` entity stayed on `docked` even though the mower was clearly running. Battery and other sensors continued to update normally, so local communication itself was fine — only the activity state was wrong.

### Root cause
Two related bugs in `EufyRobomowEntity.activity` (`custom_components/eufy_robomow/lawn_mower.py`):
1. **Wrong default for `DP118` (progress).**
   `dps.get(DP_PROGRESS, 100)` defaulted to `100` whenever the progress DP was not (yet) present in the DPS snapshot. The `DP118 >= 100 → DOCKED` branch then immediately fired, freezing the entity on "docked" even while a session was active.
2. **`DP118 == 100` was treated as "session finished".**
   As @Moater11 pointed out in the issue, `DP1=True, DP2=False, DP118=100` does *not* mean the mower has finished — it commonly occurs when the mower briefly returns to the dock to charge during an active session and will resume afterwards. Only `DP1=False` actually indicates an idle / docked state.

### Fix
`DP1` (task active) is now the single source of truth for whether a session is running. The activity logic was simplified to:
| DP1 | DP2 | DP118 | Activity |
|-----|-----|-------|----------|
| False / absent | — | — | `DOCKED` |
| True | True | — | `PAUSED` |
| True | False | 5–99 | `RETURNING` |
| True | False | 0–4 or 100 | `MOWING` |

The default for missing `DP118` was also changed from `100` → `0` so that a missing progress value can no longer flip the entity into `DOCKED` while a session is active.

### Files changed
- `custom_components/eufy_robomow/lawn_mower.py` — corrected `activity` property logic and DP118 default.
- `custom_components/eufy_robomow/const.py` — updated the inline state-table comment to match the new logic and reference the issue.

### Tests
The repository currently has no test suite, so no automated tests were added/changed. The change was reviewed against the live-DPS observations already documented in `const.py` and the additional cases reported in issue #1.

### Backwards compatibility
No config-entry, entity-id, unique-id, or DP-write changes — purely a state-mapping fix. No user action required after upgrade.
