### PR TITLE
Fix hardcoded E15 device name — use name from cloud discovery

### DIFF
--- a/custom_components/eufy_robomow/cloud.py
+++ b/custom_components/eufy_robomow/cloud.py
@@ -4,15 +4,37 @@ Authenticates via Eufy/Tuya mobile API (same flow as eufy-clean-local-key-grabbe
 and reads/writes DP155, a base64-encoded protobuf blob that stores the five
 cloud-managed settings for the E15:
 
-    field 1  (message) : const sub-msg {field1: 40}   ← sub-message, NOT bare varint
+    field 1  (message) : CUT HEIGHT — {1: mm}, mirrors DP110.  Previously assumed
+                         to be a constant {field1: 40}; live data (2026-07-02)
+                         proved writing 40 here physically resets cut height.
     field 2  (message) : travel speed  — empty = slow, {1:1} = normal, {1:2} = fast
-    field 3  (message) : edge distance — {1: mm}  (signed; negative = beyond wire)
-    field 4  (message) : pad direction — {f2:{f1: angle}, f3: fixed, f5: fixed}
+    field 3  (message) : edge distance — {1: mm}  (signed; negative = beyond wire;
+                         negatives encoded as two's-complement 64-bit varint,
+                         10 bytes).  ZERO is encoded as an EMPTY sub-message
+                         (len 0), not {1: 0} — confirmed from live app writes.
+    field 4  (message) : pad direction — {f2:{f1: angle}, f3: ?, f5: ?}
                          angle in degrees (1 unit = 1°); 0 = west (9 o'clock);
                          90 = north (12 o'clock); 180 = east (3 o'clock), etc.
-    field 5  (message) : path distance — {1: mm}
+                         f3/f5 are NOT fixed constants (f5 observed at -306 on a
+                         live device); they must be preserved verbatim on write.
+    field 5  (message) : path distance — {1: mm}; zero likely follows the same
+                         empty-sub-message convention as field 3.
     field 6  (message) : blade speed   — empty = slow, {1:1} = normal, {1:2} = fast
-    field 7  (varint)  : mirrors path_mm (same value as field 5's inner varint)
+    field 7  (varint)  : loosely tracks path_mm; device does not always update it
+
+    UNITS: distance fields always store millimetres.  The Eufy app converts
+    from its display unit before writing (observed: app "-10" in cm mode wrote
+    -100 mm; app "-2 in" wrote -50 mm).
+
+    NOTE: DP155 appears to hold the DEFAULT settings profile (writes were only
+    observed while editing the app's *default* settings screen).  Per-zone
+    customised values likely live elsewhere (DP122/DP150 territory) and are
+    not yet mapped.
+
+    WRITE STRATEGY: never rebuild this blob from a model.  Read the current
+    blob, patch ONLY the field being changed, and re-serialize every other
+    byte verbatim (see _patch_dp155).  Rebuilding from a model clobbered cut
+    height and erased edge distance on a live device (2026-07-02).
 
 NOTE: DP154 was previously assumed to hold pad direction but testing showed it does
 NOT change when the app's direction dial is moved.  DP155 field 4 is the correct
@@ -110,19 +132,15 @@ SPEED_OPTIONS = [SPEED_SLOW, SPEED_NORMAL, SPEED_FAST]
 _SPEED_TO_INT: dict[str, int] = {SPEED_SLOW: 0, SPEED_NORMAL: 1, SPEED_FAST: 2}
 _INT_TO_SPEED: dict[int, str] = {0: SPEED_SLOW, 1: SPEED_NORMAL, 2: SPEED_FAST}
 
-# ── DP155 preserved constants ──────────────────────────────────────────────────
-
-_FIELD1_CONST = 40  # field 1: inner value of sub-message {field1: 40} (constant)
-
-# Field 7 mirrors path_mm (NOT edge_mm as previously assumed).
-# Confirmed by live data: field7=90 when path_mm=90, edge_mm=70.
-
-# Field 4 contains pad direction in sub-field 2 ({f1: angle_degrees}).
-# Sub-fields 3 and 5 within field 4 are device-fixed constants; we preserve
-# them verbatim.  Observed bytes (little-endian protobuf):
-#   f3 = 1a 04 0a 02 5a 5a   (field3, len=4, inner=[f1, len=2, 0x5a, 0x5a])
-#   f5 = 28 5a               (field5, varint=90)
-_FIELD4_SUFFIX = bytes.fromhex("1a040a025a5a285a")  # f3 + f5 (fixed)
+# ── DP155 write safety ─────────────────────────────────────────────────────────
+#
+# The previous implementation rebuilt the entire DP155 blob from a 5-setting
+# model with hardcoded values for the fields it did not manage (field 1 forced
+# to 40, field 4 sub-fields forced to fixed bytes).  Live testing on
+# 2026-07-02 proved this destructive: field 1 is actually cut height (writes
+# physically reset it to 40 mm), field 4.5 held -306 on the test device, and
+# edge distance (field 3) ended up erased.  All writes now go through
+# _patch_dp155(), which preserves every byte it does not explicitly change.
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -186,39 +204,113 @@ def _encode_speed_submsg(speed: str) -> bytes:
     return _encode_field(1, 0, int_val)  # {field 1: 1 or 2}
 
 
-def _encode_field4(pad_direction: int) -> bytes:
-    """Encode DP155 field 4 body with the given pad direction angle.
+def _parse_top_level(data: bytes) -> list[tuple[int, int, bytes]]:
+    """Parse one protobuf message level into ordered (field, wire, raw) tuples.
 
-    Structure: {f2: {f1: angle}, f3: fixed, f5: fixed}
-    The f3 and f5 sub-fields are device constants preserved verbatim.
+    ``raw`` holds the field VALUE bytes only (the varint bytes for wire type 0,
+    the inner payload for wire type 2, the fixed 8/4 bytes for types 1/5).
+    Tags and length prefixes are regenerated by :func:`_serialize_fields`, so a
+    parse → serialize round trip with no modifications is byte-identical.
     """
-    f2_inner = _encode_field(1, 0, pad_direction)  # {f1: angle}
-    f2 = _encode_field(2, 2, f2_inner)  # field 2 = {f1: angle}
-    return f2 + _FIELD4_SUFFIX
+    fields: list[tuple[int, int, bytes]] = []
+    pos = 0
+    while pos < len(data):
+        tag, pos = _varint_decode(data, pos)
+        field_num = tag >> 3
+        wire_type = tag & 0x07
+        if wire_type == 0:  # varint — keep the raw varint bytes untouched
+            start = pos
+            _, pos = _varint_decode(data, pos)
+            fields.append((field_num, 0, data[start:pos]))
+        elif wire_type == 2:  # length-delimited
+            length, pos = _varint_decode(data, pos)
+            fields.append((field_num, 2, data[pos : pos + length]))
+            pos += length
+        elif wire_type == 1:  # 64-bit
+            fields.append((field_num, 1, data[pos : pos + 8]))
+            pos += 8
+        elif wire_type == 5:  # 32-bit
+            fields.append((field_num, 5, data[pos : pos + 4]))
+            pos += 4
+        else:
+            raise ValueError(
+                f"Unsupported wire type {wire_type} for field {field_num}"
+            )
+    return fields
 
 
-def _encode_dp155(
-    edge_mm: int,
-    path_mm: int,
-    travel_speed: str,
-    blade_speed: str,
-    pad_direction: int = 90,
+def _serialize_fields(fields: list[tuple[int, int, bytes]]) -> bytes:
+    """Serialize (field, wire, raw) tuples back into protobuf bytes."""
+    out = b""
+    for field_num, wire_type, raw in fields:
+        out += _varint_encode((field_num << 3) | wire_type)
+        if wire_type == 2:
+            out += _varint_encode(len(raw)) + raw
+        else:  # 0, 1, 5 — raw already holds the exact value bytes
+            out += raw
+    return out
+
+
+def _patch_dp155(
+    blob: str,
+    edge_mm: int | None = None,
+    path_mm: int | None = None,
+    travel_speed: str | None = None,
+    blade_speed: str | None = None,
+    pad_direction: int | None = None,
 ) -> str:
-    """Encode the five cloud settings into a DP155 base64 blob."""
-    payload = (
-        _encode_field(
-            1, 2, _encode_field(1, 0, _FIELD1_CONST)
-        )  # field 1: sub-msg {f1:40}
-        + _encode_field(
-            2, 2, _encode_speed_submsg(travel_speed)
-        )  # field 2: travel speed
-        + _encode_field(3, 2, _encode_field(1, 0, edge_mm))  # field 3: edge dist (mm)
-        + _encode_field(4, 2, _encode_field4(pad_direction))  # field 4: pad direction
-        + _encode_field(5, 2, _encode_field(1, 0, path_mm))  # field 5: path dist (mm)
-        + _encode_field(6, 2, _encode_speed_submsg(blade_speed))  # field 6: blade speed
-        + _encode_field(7, 0, path_mm)  # field 7: mirrors path_mm
-    )
-    return base64.b64encode(payload).decode("ascii")
+    """Surgically patch a DP155 blob, changing ONLY the requested fields.
+
+    Every field not being changed — including cut height (field 1), the
+    unknown field 4 sub-fields, field 7, and anything not yet understood —
+    is preserved byte-for-byte from the current device blob.
+    """
+    fields = _parse_top_level(base64.b64decode(blob))
+
+    def _replace(field_num: int, new_raw: bytes) -> None:
+        for i, (fn, _wt, _raw) in enumerate(fields):
+            if fn == field_num:
+                fields[i] = (field_num, 2, new_raw)
+                return
+        fields.append((field_num, 2, new_raw))  # field absent → append
+
+    if edge_mm is not None:
+        # Zero is encoded as an EMPTY sub-message, matching the app's own
+        # convention (observed live: app writes field 3 as len-0 for zero).
+        _replace(3, b"" if edge_mm == 0 else _encode_field(1, 0, edge_mm))
+
+    if path_mm is not None:
+        _replace(5, b"" if path_mm == 0 else _encode_field(1, 0, path_mm))
+        # Field 7 loosely tracks path_mm; keep it in sync when present.
+        for i, (fn, wt, _raw) in enumerate(fields):
+            if fn == 7 and wt == 0:
+                fields[i] = (7, 0, _varint_encode(path_mm))
+                break
+
+    if travel_speed is not None:
+        _replace(2, _encode_speed_submsg(travel_speed))
+
+    if blade_speed is not None:
+        _replace(6, _encode_speed_submsg(blade_speed))
+
+    if pad_direction is not None:
+        # Patch ONLY sub-field 2 inside field 4; preserve f3/f5 verbatim
+        # (f5 is NOT a constant — observed at -306 on a live device).
+        for i, (fn, wt, raw) in enumerate(fields):
+            if fn == 4 and wt == 2:
+                sub_fields = _parse_top_level(raw)
+                replaced = False
+                for j, (sfn, swt, _sraw) in enumerate(sub_fields):
+                    if sfn == 2 and swt == 2:
+                        sub_fields[j] = (2, 2, _encode_field(1, 0, pad_direction))
+                        replaced = True
+                        break
+                if not replaced:
+                    sub_fields.insert(0, (2, 2, _encode_field(1, 0, pad_direction)))
+                fields[i] = (4, 2, _serialize_fields(sub_fields))
+                break
+
+    return base64.b64encode(_serialize_fields(fields)).decode("ascii")
 
 
 def _decode_dp155(blob: str) -> dict[str, Any]:
@@ -428,21 +520,6 @@ def _unpadded_rsa(exponent: int, n: int, plaintext: bytes) -> bytes:
 # ══════════════════════════════════════════════════════════════════════════════
 
 
-class TuyaSessionError(RuntimeError):
-    """The Tuya session is invalid/expired — re-authentication should fix it."""
-
-
-# Error codes that indicate an expired or invalid session rather than a
-# device-side problem.  These trigger invalidate + re-login + retry.
-_SESSION_ERROR_CODES = {
-    "USER_SESSION_INVALID",
-    "USER_SESSION_LOSS",
-    "TOKEN_INVALID",
-    "TOKEN_EXPIRED",
-    "SING_VALIDATE_FAILED",
-}
-
-
 class EufyCloudClient:
     """Synchronous client for reading/writing Eufy cloud settings via Tuya mobile API.
 
@@ -501,26 +578,8 @@ class EufyCloudClient:
             },
             timeout=15,
         )
-        # Parse the body BEFORE raising on HTTP status: Eufy returns a JSON
-        # error payload even on 401/403, and we want to surface its message as
-        # a credential error (ValueError) rather than a generic HTTPError.
-        try:
-            data = resp.json()
-        except ValueError:
-            data = None
-
-        if not isinstance(data, dict) or "access_token" not in data:
-            msg = ""
-            if isinstance(data, dict):
-                msg = data.get("msg") or data.get("message") or data.get("error") or str(data)
-            if 400 <= resp.status_code < 500:
-                # Client error → credentials rejected by the server
-                raise ValueError(
-                    f"Eufy login rejected (HTTP {resp.status_code}): {msg}"
-                )
-            # 5xx or malformed body → transient server problem
-            resp.raise_for_status()
-            raise ValueError(f"Eufy login failed: {msg}")
+        resp.raise_for_status()
+        data = resp.json()
 
         self._eufy_token = data["access_token"]
         self._eufy_uid = data["user_info"]["id"]
@@ -582,12 +641,9 @@ class EufyCloudClient:
         payload = resp.json()
 
         if "result" not in payload:
-            error_code = str(payload.get("errorCode", "unknown"))
-            # Session/auth errors get their own type so the retry wrapper can
-            # re-authenticate; everything else is a device-side error that a
-            # fresh session would not fix.
-            if error_code in _SESSION_ERROR_CODES or "SESSION" in error_code.upper():
-                raise TuyaSessionError(f"Session error [{error_code}]: {payload}")
+            # Surface device-side errors with a recognisable prefix so callers
+            # can distinguish them from transient session / auth failures.
+            error_code = payload.get("errorCode", "unknown")
             raise RuntimeError(f"Device error [{error_code}]: {payload}")
 
         return payload["result"]
@@ -635,16 +691,19 @@ class EufyCloudClient:
         self._eufy_token = None
 
     def _tuya_request_with_retry(self, *args, **kwargs) -> Any:
-        """Call _tuya_request; on session expiry invalidate, re-login and retry once.
+        """Call _tuya_request; on session/auth failure invalidate and retry once.
 
         Device-side errors (DEVICE_OFFLINE, etc.) are not retried because
         invalidating the session won't fix them.
         """
         try:
             return self._tuya_request(*args, **kwargs)
-        except TuyaSessionError as exc:
+        except RuntimeError as exc:
+            # "Device error [...]" prefix → device-side issue, no point retrying
+            if str(exc).startswith("Device error"):
+                raise
             _LOGGER.warning(
-                "Tuya session expired (%s) — re-authenticating and retrying once", exc
+                "Tuya API call failed, invalidating sessions and retrying once"
             )
             self._invalidate_sessions()
             return self._tuya_request(*args, **kwargs)
@@ -758,40 +817,43 @@ class EufyCloudClient:
         blade_speed: str | None = None,
         pad_direction: int | None = None,
     ) -> None:
-        """Write updated cloud settings to DP155.
+        """Write updated cloud settings to DP155 via surgical read-modify-write.
 
-        All five settings are always written together.  Unchanged fields are
-        read from the device first to preserve them.
+        Only the fields passed as non-None are changed.  The current blob is
+        fetched from the cloud and every other byte — cut height (field 1),
+        the unknown field 4 sub-fields, field 7, and any fields not yet
+        understood — is preserved verbatim.  This replaces the previous
+        rebuild-from-model approach, which clobbered cut height to 40 mm and
+        erased edge distance on a live device (2026-07-02).
         """
-        # Read current values so we can fill in any unchanged fields.
-        current = self.get_settings()
+        raw_dps, _settings = self.get_all_dps()
+        current_blob = raw_dps.get("155")
+        if not current_blob:
+            raise RuntimeError("DP155 not present in cloud response; cannot write")
 
-        new_edge_mm = edge_mm if edge_mm is not None else current["edge_mm"]
-        new_path_mm = path_mm if path_mm is not None else current["path_mm"]
-        new_travel_speed = (
-            travel_speed if travel_speed is not None else current["travel_speed"]
-        )
-        new_blade_speed = (
-            blade_speed if blade_speed is not None else current["blade_speed"]
-        )
-        new_pad_direction = (
-            pad_direction if pad_direction is not None else current["pad_direction"]
+        new_blob = _patch_dp155(
+            current_blob,
+            edge_mm=edge_mm,
+            path_mm=path_mm,
+            travel_speed=travel_speed,
+            blade_speed=blade_speed,
+            pad_direction=pad_direction,
         )
 
-        blob155 = _encode_dp155(
-            new_edge_mm,
-            new_path_mm,
-            new_travel_speed,
-            new_blade_speed,
-            new_pad_direction,
-        )
+        if new_blob == current_blob:
+            _LOGGER.debug("DP155 unchanged after patch; skipping publish")
+            return
+
         _LOGGER.debug(
-            "Publishing DP155: edge=%dmm path=%dmm travel=%s blade=%s pad=%d°",
-            new_edge_mm,
-            new_path_mm,
-            new_travel_speed,
-            new_blade_speed,
-            new_pad_direction,
+            "Publishing DP155 patch (edge=%s path=%s travel=%s blade=%s pad=%s): "
+            "%s -> %s",
+            edge_mm,
+            path_mm,
+            travel_speed,
+            blade_speed,
+            pad_direction,
+            current_blob,
+            new_blob,
         )
         self._tuya_request_with_retry(
             "tuya.m.device.dp.publish",
@@ -799,6 +861,6 @@ class EufyCloudClient:
                 "devId": self._device_id,
                 "gwId": self._device_id,
                 "uid": self._tuya_username,
-                "dps": {"155": blob155},
+                "dps": {"155": new_blob},
             },
         )

--- a/custom_components/eufy_robomow/config_flow.py
+++ b/custom_components/eufy_robomow/config_flow.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_LOCAL_KEY,
     CONF_EUFY_EMAIL,
     CONF_EUFY_PASSWORD,
+    CONF_DEVICE_NAME,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -172,6 +173,7 @@ class EufyRobomowConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_LOCAL_KEY:     local_key,
                         CONF_EUFY_EMAIL:    self._email,
                         CONF_EUFY_PASSWORD: self._password,
+                        CONF_DEVICE_NAME:   device_name, 
                     },
                 )
 

--- a/custom_components/eufy_robomow/const.py
+++ b/custom_components/eufy_robomow/const.py
@@ -21,6 +21,7 @@ CONF_DEVICE_ID = "device_id"
 CONF_LOCAL_KEY = "local_key"
 CONF_EUFY_EMAIL = "eufy_email"  # optional — enables cloud settings
 CONF_EUFY_PASSWORD = "eufy_password"  # optional — enables cloud settings
+CONF_DEVICE_NAME = "device_name"
 
 # ── Cloud settings poll interval ───────────────────────────────────────────────
 # Cloud settings are fetched at most once every N seconds (much slower than local).

--- a/custom_components/eufy_robomow/const.py
+++ b/custom_components/eufy_robomow/const.py
@@ -50,8 +50,13 @@ EDGE_DISTANCE_STEP = 1  # cm
 
 # ── Path distance — app has exactly 3 options: 8 / 10 / 12 cm ────────────────
 # Stored as mm in DP155 field 5.  Exposed as a SelectEntity.
-PATH_DISTANCE_OPTIONS: list[str] = ["8 cm", "10 cm", "12 cm"]
-PATH_DISTANCE_MM: dict[str, int] = {"8 cm": 80, "10 cm": 100, "12 cm": 120}
+# Updated to show inches as well since the app can be changed to that too
+PATH_DISTANCE_MM: dict[str, int] = {
+    "8 cm (3.1 in)": 80,
+    "10 cm (3.9 in)": 100,
+    "12 cm (4.7 in)": 120,
+}
+PATH_DISTANCE_OPTIONS: list[str] = list(PATH_DISTANCE_MM.keys())
 
 # ── Pad direction (mowing path angle) — DP155 field 4 ─────────────────────────
 # Stored as an integer in DP155 field 4, sub-field 2, inner field 1.

--- a/custom_components/eufy_robomow/const.py
+++ b/custom_components/eufy_robomow/const.py
@@ -65,19 +65,32 @@ PAD_DIRECTION_MAX = 359  # degrees (full rotation)
 PAD_DIRECTION_STEP = 1  # degrees
 
 # ── DPS READ (status) ──────────────────────────────────────────────────────────
-# Confirmed via live monitoring of Eufy E15 (Tuya v3.5)
+# Confirmed via live monitoring of Eufy E18 / Terramow S1200 (Tuya v3.5)
 
-DP_TASK_ACTIVE = "1"  # bool  True = a mowing/returning session is running
+DP_TASK_ACTIVE = "1"  # bool  True = mowing, returning, or manual/remote control active
 DP_PAUSED = "2"  # bool  True = session paused, False = actively moving
 DP_BATTERY = "8"  # int   Battery level 0–100 %
 DP_VOLUME = "26"  # int   Speaker volume 0–100 %
 DP_CHILD_PROTECTION = "47"  # bool  True = child/pet protection active
 DP_SIGNAL = "109"  # int   Signal strength (raw value; e.g. 50 → −50 dBm)
 DP_CUT_HEIGHT = "110"  # int   Blade height in mm (e.g. 40)
-DP_LIVE_VIEW = "114"  # int   Live-view/camera state:
-#       32  = idle (no live view)
-#       103 = camera enabled (user opened live view)
-#       104 = camera disabled (user closed live view)
+DP_LAST_NOTIFICATION = "114"  # int  Most recent N-code notification from mower.
+#       DP114 is updated whenever the mower emits an N-code event (verbal, toast,
+#       push, or silent). Confirmed on E18 / Terramow S1200:
+#       31  = N31  child lock on                    (toast + verbal)
+#       32  = N32  child lock off                   (toast + verbal)
+#       41  = N41  mowing resumed after charge      (silent)
+#       43  = N43  scheduled mowing started         (push notification)
+#       65  = N65  cannot reach target area         (push notification)
+#       76  = N76  returning to dock to charge      (silent)
+#       103 = N103 live camera on                   (toast)
+#       104 = N104 live camera off                  (toast)
+#       106 = N106 camera preparing                 (silent)
+#       114 = N114 sunset, session cancelled        (toast + verbal)
+#       127 = N127 loading system / boot            (verbal)
+DP_ERROR_CODE = "115"  # int  Error/obstacle code, present during navigation errors
+#       Appears alongside N65 (cannot reach target). Observed value:
+#       904 = cannot reach target area
 DP_PROGRESS = "118"  # int   0–100 % progress of current action
 #       0   = idle / mowing
 #       1-99 = saving map or returning to base
@@ -115,11 +128,23 @@ CUT_HEIGHT_STEP = 5  # mm
 #
 #  DP1 absent,  DP2 absent                    → DOCKED  (cold / never started)
 #  DP1=True,    DP2=False,  DP118=0           → MOWING
-#  DP1=True,    DP2=False,  DP118 5–99        → RETURNING (progress back to base)
-#  DP1=True,    DP2=False,  DP118=100         → MOWING  (briefly docked mid-session
-#                                               for charging; DP1 still True so we
-#                                               report MOWING not DOCKED)
+#  DP1=True,    DP2=False,  DP118 5–99        → RETURNING (physical return to base)
+#                                               ...OR map saving (see below)
 #  DP1 absent/False                           → DOCKED  (no active session)
 #  DP1=True,    DP2=True                      → PAUSED
 #
-RETURNING_THRESHOLD = 5  # DP118 ≥ this value while DP1 active = RETURNING
+# Map-save disambiguation:
+#  When the mower physically docks at end-of-session, DP118 resets to 0 and DP1
+#  briefly goes False then True again for map saving — during which DP118 climbs
+#  again in the same 5–99 range.  Mid-session charge docks look similar but DP1
+#  stays True throughout (no False transition).  The entity tracks this state
+#  machine to suppress RETURNING during map saving (see _handle_coordinator_update).
+#
+RETURNING_THRESHOLD = 5  # DP118 ≥ this value while DP1 active = potentially RETURNING
+
+# After the mower physically docks at end-of-session, DP1 briefly goes False then
+# True again for map saving.  We suppress RETURNING during that map-save phase.
+# If DP1 stays False longer than this many polls the session truly ended (e.g.
+# sunset cancel); abandon the map-save expectation so the next real session is fresh.
+# At POLL_INTERVAL=10 s this is 2 minutes.
+MAP_SAVE_TIMEOUT_POLLS = 12

--- a/custom_components/eufy_robomow/coordinator.py
+++ b/custom_components/eufy_robomow/coordinator.py
@@ -37,7 +37,7 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
 
     If an EufyCloudClient is provided, cloud DPS are also fetched every
     CLOUD_POLL_INTERVAL seconds (default 5 min).  ALL raw cloud DPS are merged
-    into coordinator.data so every DP is visible as a HA sensor — even cloud-only
+    into coordinator.data so every DP is visible as a HA sensor - even cloud-only
     ones like DP3, DP4, DP36, DP102-DP185 that the local Tuya protocol never
     returns.  For any DP present in both transports the local (real-time) value
     takes precedence.
@@ -65,12 +65,18 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         self._device = self._make_device()
         # Use float('-inf') so the first poll always fetches cloud DPS
         self._cloud_last_fetch: float = float("-inf")
-        # Consecutive cloud failures — used for exponential backoff
+        # Consecutive cloud failures - used for exponential backoff
         self._cloud_consecutive_failures: int = 0
         # Track consecutive local-poll failures to know when to recreate the device
         self._consecutive_errors: int = 0
         # Set of all DP keys seen so far (local + cloud), used to detect new DPs
         self._known_dps: set[str] = set()
+        # Most recent raw snapshots, kept separately so entities can distinguish
+        # local truth from stale cloud echoes.
+        self._last_local_dps: dict = {}
+        self._last_cloud_dps: dict = {}
+        self._last_local_update: float = float("-inf")
+        self._last_cloud_update: float = float("-inf")
         # Callbacks invoked when previously-unseen DPS keys appear in a poll.
         # Registered by sensor.py so it can add generic sensors on-the-fly.
         # Callbacks receive the current dps dict as their sole argument.
@@ -99,25 +105,25 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         d.set_socketPersistent(False)
         return d
 
-    # ── polling ───────────────────────────────────────────────────────────────
+    #  polling 
 
     async def _async_update_data(self) -> dict:
         """Fetch DPS from device (local) and optionally from cloud.
 
         Strategy:
-          1. Local poll  — always, every POLL_INTERVAL seconds (~10 s).
-          2. Cloud poll  — every CLOUD_POLL_INTERVAL seconds (~5 min).
-             • Fetches ALL raw cloud DPS via tuya.m.device.dp.get.
-             • Merges them into the dict: local values win for any DP in both.
-             • Decoded DP155 settings are stored under cloud_* keys.
-          3. Carry-forward — when cloud poll is not due (or fails), all keys from
+          1. Local poll  - always, every POLL_INTERVAL seconds (~10 s).
+          2. Cloud poll  - every CLOUD_POLL_INTERVAL seconds (~5 min).
+              Fetches ALL raw cloud DPS via tuya.m.device.dp.get.
+              Merges them into the dict: local values win for any DP in both.
+              Decoded DP155 settings are stored under cloud_* keys.
+          3. Carry-forward - when cloud poll is not due (or fails), all keys from
              the previous coordinator.data that are not in the fresh local dps are
              carried forward so cloud-only entities never go unavailable.
-          4. New-DP detection — after the full merge, new DPS keys fire the
+          4. New-DP detection - after the full merge, new DPS keys fire the
              _new_dp_callbacks with the complete dps dict so sensor.py can
              register generic sensors immediately.
         """
-        # ── 1. Local DPS (every POLL_INTERVAL seconds) ────────────────────────
+        #  1. Local DPS (every POLL_INTERVAL seconds) 
         try:
             result = await self.hass.async_add_executor_job(self._device.status)
         except Exception as exc:  # noqa: BLE001
@@ -148,13 +154,17 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         dps: dict = result.get("dps", {})
         local_dp_keys: set[str] = set(dps.keys())
 
+        self._last_local_dps = dict(dps)
+        now = time.monotonic()
+        self._last_local_update = now
+
         _LOGGER.debug("Local DPS update: %s", dps)
 
-        # ── 2. Cloud DPS + settings (every CLOUD_POLL_INTERVAL seconds) ───────
+        #  2. Cloud DPS + settings (every CLOUD_POLL_INTERVAL seconds) 
         # Two guards before attempting a cloud poll:
-        #   a) Sun above horizon — mower cannot operate at night, no point refreshing.
+        #   a) Sun above horizon - mower cannot operate at night, no point refreshing.
         #      Uses HA's sun.sun entity; if unavailable defaults to allowing the poll.
-        #   b) Exponential backoff on consecutive failures (5 min → 10 → 20 → 40 → 60).
+        #   b) Exponential backoff on consecutive failures (5 min  10  20  40  60).
         #      _cloud_last_fetch is updated on BOTH success AND failure so a failed
         #      login is not retried every 10 s (which would hammer the Eufy API and
         #      interfere with other integrations sharing the same account).
@@ -164,7 +174,7 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
             _sun_below_horizon = _sun is not None and _sun.state == "below_horizon"
 
             if _sun_below_horizon:
-                _LOGGER.debug("Sun below horizon — skipping cloud poll")
+                _LOGGER.debug("Sun below horizon - skipping cloud poll")
                 self._carry_forward_cloud_data(dps, local_dp_keys)
             else:
                 backoff = min(
@@ -193,6 +203,8 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
 
                         self._cloud_last_fetch = now
                         self._cloud_consecutive_failures = 0
+                        self._last_cloud_dps = dict(raw_cloud_dps)
+                        self._last_cloud_update = now
                         _LOGGER.debug(
                             "Cloud poll: %d raw DPS merged, settings=%s",
                             len(raw_cloud_dps),
@@ -215,10 +227,10 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
                         self._cloud_last_fetch = now
                         self._carry_forward_cloud_data(dps, local_dp_keys)
                 else:
-                    # Not yet due — carry forward previous cloud data
+                    # Not yet due - carry forward previous cloud data
                     self._carry_forward_cloud_data(dps, local_dp_keys)
 
-        # ── 3. New-DP detection (after full merge) ────────────────────────────
+        #  3. New-DP detection (after full merge) 
         current_all_keys = set(dps.keys())
         new_keys = current_all_keys - self._known_dps
 
@@ -255,7 +267,7 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
             if key not in local_dp_keys:
                 dps[key] = val
 
-    # ── commands ──────────────────────────────────────────────────────────────
+    #  commands 
 
     async def async_send_command(self, dp: str, value) -> bool:
         """Write a single DPS value to the device. Returns True on success."""

--- a/custom_components/eufy_robomow/lawn_mower.py
+++ b/custom_components/eufy_robomow/lawn_mower.py
@@ -26,6 +26,7 @@ from .const import (
     CMD_RESUME,
     CMD_DOCK,
     RETURNING_THRESHOLD,
+    CONF_DEVICE_NAME,
 )
 from .coordinator import EufyMowerCoordinator
 
@@ -61,11 +62,15 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
         super().__init__(coordinator)
         self._entry = entry
         self._attr_unique_id = f"{entry.data[CONF_DEVICE_ID]}_mower"
+        # Note: The cloud device names seem to be internal model IDs.
+        # E18 returns "eufy S1200" assuming to be based on the Terramow S1200
+        # E15 equivalent is unknown -- falls back to "Eufy Robomow" if not found
+        name = entry.data.get(CONF_DEVICE_NAME, "Eufy Robomow")
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.data[CONF_DEVICE_ID])},
-            name="Eufy Robomow E15",
+            name=name,
             manufacturer="Eufy (Anker)",
-            model="E15",
+            model=name,
         )
 
     # ── activity ──────────────────────────────────────────────────────────────

--- a/custom_components/eufy_robomow/lawn_mower.py
+++ b/custom_components/eufy_robomow/lawn_mower.py
@@ -1,7 +1,23 @@
-"""Lawn mower entity for Eufy Robomow."""
+"""Lawn mower entity for Eufy Robomow.
+
+State machine driven by DP1 EDGES interpreted by context, not DP1 levels.
+Confirmed protocol behavior (live monitoring, stopwatch verified):
+
+- DP1 True->False after a confirmed session  = physical return journey begins
+  (N30/N76 fires at this moment; journey takes 1-2 minutes)
+- DP1 False->True while returning            = mower physically docked;
+  DP118 then climbs 0->100 = MAP SAVING (mower already docked, stay DOCKED)
+- DP1 True->False while map saving           = map save complete (stay DOCKED)
+- DP1 False->True from idle with no N-code, no DP126 increment
+                                             = scheduler flicker (stay DOCKED)
+- DP126 increments only during real mowing   = strongest mowing confirmation
+- N43 = scheduled start, N41 = resumed after charge (both mean MOWING)
+- HA-initiated commands generate NO N-code; we track our own CMD_START instead
+"""
 from __future__ import annotations
 
 import logging
+import time
 
 from homeassistant.components.lawn_mower import (
     LawnMowerActivity,
@@ -9,7 +25,6 @@ from homeassistant.components.lawn_mower import (
     LawnMowerEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -20,19 +35,35 @@ from .const import (
     CONF_DEVICE_ID,
     DP_TASK_ACTIVE,
     DP_PAUSED,
-    DP_PROGRESS,
-    DP_AREA,
     CMD_START,
     CMD_PAUSE,
     CMD_RESUME,
     CMD_DOCK,
-    RETURNING_THRESHOLD,
-    MAP_SAVE_TIMEOUT_POLLS,
-    CONF_DEVICE_NAME,
 )
 from .coordinator import EufyMowerCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# DPs referenced directly (documented in const.py / FINDINGS):
+DP_NCODE = "114"  # N-code notification register (NOT a live-view state)
+DP_AREA = "126"   # mowed-area counter; increments ONLY during real mowing
+
+# N-codes that mark state transitions (confirmed via live monitoring):
+RETURN_NCODES = {30, 76}  # N30 low battery return, N76 returning to dock
+ACTIVE_NCODES = {41, 43}  # N41 resumed after charge, N43 scheduled start
+
+RETURNING_TIMEOUT = 300        # s - failsafe if dock arrival never observed
+MAP_SAVE_TIMEOUT = 240         # s - map saves complete well under 2 minutes
+OPTIMISTIC_START_WINDOW = 120  # s - trust our own CMD_START for this long
+
+# Internal phases:
+#   idle      - no session; DOCKED
+#   candidate - DP1 rose but session not yet confirmed; DOCKED (suppresses
+#               scheduler flickers; promoted to mowing by DP126/N-code)
+#   mowing    - confirmed active session; MOWING
+#   returning - physical return journey (DP1 dropped after confirmed session,
+#               or N30/N76 fired); RETURNING
+#   map_save  - docked, DP118 climbing; DOCKED
 
 
 async def async_setup_entry(
@@ -45,7 +76,7 @@ async def async_setup_entry(
 
 
 class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity):
-    """Represents the Eufy E15 robot mower."""
+    """Represents the Eufy Robomow mower."""
 
     _attr_has_entity_name = True
     _attr_translation_key = "lawn_mower"
@@ -64,139 +95,161 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
         super().__init__(coordinator)
         self._entry = entry
         self._attr_unique_id = f"{entry.data[CONF_DEVICE_ID]}_mower"
-        # Note: The cloud device names seem to be internal model IDs.
-        # E18 returns "eufy S1200" assuming to be based on the Terramow S1200
-        # E15 equivalent is unknown -- falls back to "Eufy Robomow" if not found
-        name = entry.data.get(CONF_DEVICE_NAME, "Eufy Robomow")
+        # Dynamic device name saved by config_flow (PR #10). Falls back
+        # gracefully if the entry predates the fix.
+        name = entry.data.get("device_name", "Eufy Robomow")
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.data[CONF_DEVICE_ID])},
             name=name,
             manufacturer="Eufy (Anker)",
             model=name,
         )
-        # Map-save state tracking (see _handle_coordinator_update docstring)
-        self._prev_dp1: bool = False
-        self._prev_dp118: int = 0
-        self._was_returning: bool = False
-        self._expecting_map_save: bool = False
-        self._false_poll_count: int = 0
-        self._in_map_save: bool = False
-        # Flicker suppression: DP126 (mowed area) increments during real mowing
-        # but never changes during post-session DP1=True flickers.
-        self._prev_dp126: int = 0
-        self._dp1_true_polls: int = 0
-        self._dp126_confirmed: bool = False
 
-    # ── map-save disambiguation ────────────────────────────────────────────────
+        # --- state machine -------------------------------------------------
+        self._phase: str = "idle"
+        self._phase_ts: float = time.monotonic()
+        self._prev_dp1: bool | None = None
+        self._prev_ncode: int | None = None
+        self._prev_area: int | None = None
+        self._own_start_ts: float | None = None
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _dps(self) -> dict:
+        return (
+            getattr(self.coordinator, "_last_local_dps", None)
+            or self.coordinator.data
+            or {}
+        )
+
+    def _set_phase(self, phase: str, now: float) -> None:
+        if phase != self._phase:
+            _LOGGER.debug("Mower phase: %s -> %s", self._phase, phase)
+            self._phase = phase
+            self._phase_ts = now
+
+    # ── state machine (runs ONCE per coordinator refresh) ───────────────────
 
     def _handle_coordinator_update(self) -> None:
-        """Track DP1/DP118 transitions to suppress RETURNING during map saving.
+        dps = self._dps()
+        dp1 = bool(dps.get(DP_TASK_ACTIVE, False))
+        ncode = dps.get(DP_NCODE)
+        area = dps.get(DP_AREA)
+        now = time.monotonic()
 
-        Confirmed sequences:
-          mowing    → DP1=True,  DP118=0            → MOWING
-          returning → DP1=True,  DP118=5–99         → RETURNING
-          dock      → DP1=False, DP118 resets
-          map save  → DP1=True,  DP118 climbs 0→100 → DOCKED
-          done      → DP1=False
+        first_update = self._prev_dp1 is None
 
-        In-place map save (stop without docking):
-          DP118 drops from ≥5 to 1–4 while DP1 stays True, then climbs back.
+        ncode_changed = (
+            not first_update
+            and self._prev_ncode is not None
+            and ncode != self._prev_ncode
+        )
+        area_incremented = (
+            not first_update
+            and self._prev_area is not None
+            and area is not None
+            and area > self._prev_area
+        )
 
-        DP2 (pause/resume) is not tracked here; those cycles have no effect
-        on map-save detection.
-        """
-        dps = self.coordinator.data or {}
-        dp1   = dps.get(DP_TASK_ACTIVE, False)
-        dp118 = dps.get(DP_PROGRESS, 0)
-        dp126 = dps.get(DP_AREA, 0)
+        # 1) N-code driven transitions. These work even when DP1 does not
+        #    change (mid-session charge cycles can keep DP1 True throughout).
+        if ncode_changed and ncode in RETURN_NCODES:
+            self._set_phase("returning", now)
+        elif ncode_changed and ncode in ACTIVE_NCODES:
+            self._set_phase("mowing", now)
 
-        if dp1:
-            self._false_poll_count = 0
-
-            if not self._prev_dp1:
-                # DP1 just went True: new mow session or post-dock map save.
-                if self._expecting_map_save:
-                    self._in_map_save = True
-                    self._expecting_map_save = False
+        # 2) DP1 rising edge (False -> True)
+        if not first_update and dp1 and not self._prev_dp1:
+            if self._phase == "returning":
+                # Physical arrival at the dock. DP118 will now climb 0->100:
+                # that is map saving, the mower is ALREADY docked.
+                self._set_phase("map_save", now)
+            elif self._phase != "mowing":
+                if (
+                    self._own_start_ts is not None
+                    and now - self._own_start_ts < OPTIMISTIC_START_WINDOW
+                ):
+                    # We sent CMD_START ourselves (no N-code fires for
+                    # HA-initiated commands).
+                    self._set_phase("mowing", now)
+                elif ncode in ACTIVE_NCODES and ncode != self._prev_ncode:
+                    # N43/N41 arrived in the same poll as the rising edge.
+                    # Deliberately does NOT require a known previous value:
+                    # DP114 can be absent from the local DPS until a session
+                    # starts (observed 2026-07-03: None -> 43 at a scheduled
+                    # start caused a 4-minute MOWING lag under the stricter
+                    # guard). A stale active code after a restart cannot
+                    # misfire here because it would equal _prev_ncode.
+                    self._set_phase("mowing", now)
                 else:
-                    self._in_map_save = False
-                self._was_returning = False
-                self._dp1_true_polls = 0
-                self._dp126_confirmed = False
+                    # Could be a real app-initiated session or a scheduler
+                    # flicker. Stay DOCKED until DP126/N-code confirms.
+                    self._set_phase("candidate", now)
+
+        # 3) DP1 falling edge (True -> False)
+        if not first_update and not dp1 and self._prev_dp1:
+            if self._phase == "map_save":
+                self._set_phase("idle", now)       # map save finished
+            elif self._phase == "mowing":
+                self._set_phase("returning", now)  # physical return begins
             else:
-                # DP1 stayed True.
-                self._dp1_true_polls += 1
-                if dp126 != self._prev_dp126:
-                    self._dp126_confirmed = True
-                if dp118 >= RETURNING_THRESHOLD:
-                    self._was_returning = True
-                # In-place map save: DP118 drops from return-range to near-zero
-                # while DP1 never dips False (stop-without-dock sequence).
-                if (self._prev_dp118 >= RETURNING_THRESHOLD
-                        and dp118 < RETURNING_THRESHOLD
-                        and dp118 > 0
-                        and not self._in_map_save):
-                    self._in_map_save = True
-                    self._was_returning = False
+                self._set_phase("idle", now)       # flicker / unconfirmed end
 
-        else:
-            self._false_poll_count += 1
+        # 4) Confirmation: DP126 increments only during real mowing. Promotes
+        #    candidates, and self-corrects a wrong phase after HA restarts or
+        #    brief DP1 blips (map save never increments DP126).
+        if dp1 and area_incremented and self._phase in (
+            "candidate",
+            "idle",
+            "map_save",
+        ):
+            self._set_phase("mowing", now)
 
-            if self._prev_dp1:
-                # DP1 just went False: docked after return, map save ended, or cancelled.
-                if self._in_map_save:
-                    # Map saving finished — next DP1 True is a fresh session.
-                    self._expecting_map_save = False
-                elif self._was_returning:
-                    # Completed a return trip and docked; post-dock map save follows.
-                    self._expecting_map_save = True
-                # else: cancelled before returning — leave _expecting_map_save alone;
-                # the timeout below clears it if no map save materialises.
-                self._in_map_save = False
-                self._was_returning = False
-
-            # DP1 stayed False past the timeout: session truly ended (e.g. sunset
-            # cancel with no map save).  Clear so the next scheduled mow starts fresh.
-            if self._false_poll_count > MAP_SAVE_TIMEOUT_POLLS:
-                self._expecting_map_save = False
+        # 5) Failsafes
+        if (
+            self._phase == "returning"
+            and now - self._phase_ts > RETURNING_TIMEOUT
+        ):
+            self._set_phase("idle", now)
+        if (
+            self._phase == "map_save"
+            and now - self._phase_ts > MAP_SAVE_TIMEOUT
+        ):
+            self._set_phase("idle", now)
 
         self._prev_dp1 = dp1
-        self._prev_dp118 = dp118
-        self._prev_dp126 = dp126
+        self._prev_ncode = ncode
+        self._prev_area = area
         super()._handle_coordinator_update()
 
-    # ── activity ──────────────────────────────────────────────────────────────
+    # ── activity (pure read of the phase) ────────────────────────────────────
 
     @property
     def activity(self) -> LawnMowerActivity:
-        dps = self.coordinator.data
-        dp1   = dps.get(DP_TASK_ACTIVE, False)
-        dp2   = dps.get(DP_PAUSED,      False)
-        dp118 = dps.get(DP_PROGRESS,    0)
+        dps = self._dps()
+        dp1 = bool(dps.get(DP_TASK_ACTIVE, False))
+        dp2 = bool(dps.get(DP_PAUSED, False))
 
-        if not dp1:
-            return LawnMowerActivity.DOCKED
-        if dp2:
+        if dp1 and dp2:
             return LawnMowerActivity.PAUSED
-        if self._in_map_save:
-            return LawnMowerActivity.DOCKED
-        if RETURNING_THRESHOLD <= dp118 < 100:
+        if self._phase == "returning":
             return LawnMowerActivity.RETURNING
-        # Suppress MOWING during post-session DP1 flickers: DP126 never increments
-        # during flickers but does so every 30–60 s during real mowing.
-        if self._dp126_confirmed or self._dp1_true_polls < 2:
+        if self._phase == "mowing" and dp1:
             return LawnMowerActivity.MOWING
+        # idle, candidate, map_save (and mowing without DP1) read as DOCKED
         return LawnMowerActivity.DOCKED
 
-    # ── commands ──────────────────────────────────────────────────────────────
+    # ── commands ─────────────────────────────────────────────────────────────
 
     async def async_start_mowing(self) -> None:
         """Start or resume mowing."""
-        current = self.activity
-        if current == LawnMowerActivity.PAUSED:
+        if self.activity == LawnMowerActivity.PAUSED:
             dp, val = CMD_RESUME
         else:
             dp, val = CMD_START
+            # No N-code fires for HA-initiated starts; remember that WE
+            # started this so the rising edge is trusted as real mowing.
+            self._own_start_ts = time.monotonic()
         await self.coordinator.async_send_command(dp, val)
 
     async def async_pause(self) -> None:

--- a/custom_components/eufy_robomow/lawn_mower.py
+++ b/custom_components/eufy_robomow/lawn_mower.py
@@ -26,6 +26,7 @@ from .const import (
     CMD_RESUME,
     CMD_DOCK,
     RETURNING_THRESHOLD,
+    MAP_SAVE_TIMEOUT_POLLS,
     CONF_DEVICE_NAME,
 )
 from .coordinator import EufyMowerCoordinator
@@ -72,6 +73,71 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
             manufacturer="Eufy (Anker)",
             model=name,
         )
+        # Map-save state tracking (see _handle_coordinator_update docstring)
+        self._prev_dp1: bool = False
+        self._was_returning: bool = False
+        self._expecting_map_save: bool = False
+        self._false_poll_count: int = 0
+        self._in_map_save: bool = False
+
+    # ── map-save disambiguation ────────────────────────────────────────────────
+
+    def _handle_coordinator_update(self) -> None:
+        """Track DP1/DP118 transitions to distinguish map saving from returning.
+
+        End-of-session sequence:
+          returning  → DP1=True,  DP118 climbs          (RETURNING)
+          dock       → DP1 briefly False, DP118 resets to 0
+          map save   → DP1=True,  DP118 climbs again    (should be MOWING)
+          done       → DP1=False
+
+        Mid-session charge dock: DP1 stays True throughout — no False transition,
+        so _expecting_map_save is never set and a subsequent return shows RETURNING.
+
+        Cancelled session (e.g. sunset): DP1 goes False and stays False.
+        After MAP_SAVE_TIMEOUT_POLLS consecutive False polls we abandon the
+        map-save expectation so the next scheduled mow starts fresh.
+        """
+        dps = self.coordinator.data or {}
+        dp1   = dps.get(DP_TASK_ACTIVE, False)
+        dp118 = dps.get(DP_PROGRESS, 0)
+
+        if dp1:
+            self._false_poll_count = 0
+
+            if not self._prev_dp1:
+                # DP1 just went True — either a new mow session or map-save start.
+                if self._expecting_map_save:
+                    self._in_map_save = True
+                    self._expecting_map_save = False
+                else:
+                    self._in_map_save = False
+                self._was_returning = False
+
+            if dp118 >= RETURNING_THRESHOLD:
+                self._was_returning = True
+
+        else:
+            self._false_poll_count += 1
+
+            if self._prev_dp1:
+                # DP1 just went False — mower docked after a return trip, OR session
+                # was cancelled.  Only arm map-save expectation if we actually saw a
+                # return trip AND we aren't already in a map-save phase (which would
+                # mean this False is the end of map saving, not the dock-before-save).
+                if self._was_returning and not self._in_map_save:
+                    self._expecting_map_save = True
+                self._in_map_save = False
+                self._was_returning = False
+
+            # Safety: if DP1 stays False longer than the timeout the session really
+            # ended (e.g. sunset cancel with no map save).  Clear the expectation so
+            # the next session starts clean.
+            if self._false_poll_count > MAP_SAVE_TIMEOUT_POLLS:
+                self._expecting_map_save = False
+
+        self._prev_dp1 = dp1
+        super()._handle_coordinator_update()
 
     # ── activity ──────────────────────────────────────────────────────────────
 
@@ -87,14 +153,15 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
             return LawnMowerActivity.PAUSED
 
         if dp1 and not dp2:
-            # DP118 5–99 → mower returning to base
-            # DP118=100 while DP1=True means briefly docked mid-session for
-            # charging (will resume); treat as MOWING, not RETURNING.
-            if RETURNING_THRESHOLD <= dp118 < 100:
+            # DP118 5–99 while not in post-dock map-save phase → physically returning.
+            # _in_map_save suppresses RETURNING when DP118 climbs after a dock event.
+            if RETURNING_THRESHOLD <= dp118 < 100 and not self._in_map_save:
                 try:
                     return LawnMowerActivity.RETURNING
                 except AttributeError:
                     return LawnMowerActivity.MOWING
+            if self._in_map_save:
+                return LawnMowerActivity.DOCKED
             return LawnMowerActivity.MOWING
 
         # DP1 absent or False → no active session → docked / idle

--- a/custom_components/eufy_robomow/lawn_mower.py
+++ b/custom_components/eufy_robomow/lawn_mower.py
@@ -21,6 +21,7 @@ from .const import (
     DP_TASK_ACTIVE,
     DP_PAUSED,
     DP_PROGRESS,
+    DP_AREA,
     CMD_START,
     CMD_PAUSE,
     CMD_RESUME,
@@ -75,68 +76,93 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
         )
         # Map-save state tracking (see _handle_coordinator_update docstring)
         self._prev_dp1: bool = False
+        self._prev_dp118: int = 0
         self._was_returning: bool = False
         self._expecting_map_save: bool = False
         self._false_poll_count: int = 0
         self._in_map_save: bool = False
+        # Flicker suppression: DP126 (mowed area) increments during real mowing
+        # but never changes during post-session DP1=True flickers.
+        self._prev_dp126: int = 0
+        self._dp1_true_polls: int = 0
+        self._dp126_confirmed: bool = False
 
     # ── map-save disambiguation ────────────────────────────────────────────────
 
     def _handle_coordinator_update(self) -> None:
-        """Track DP1/DP118 transitions to distinguish map saving from returning.
+        """Track DP1/DP118 transitions to suppress RETURNING during map saving.
 
-        End-of-session sequence:
-          returning  → DP1=True,  DP118 climbs          (RETURNING)
-          dock       → DP1 briefly False, DP118 resets to 0
-          map save   → DP1=True,  DP118 climbs again    (should be MOWING)
-          done       → DP1=False
+        Confirmed sequences:
+          mowing    → DP1=True,  DP118=0            → MOWING
+          returning → DP1=True,  DP118=5–99         → RETURNING
+          dock      → DP1=False, DP118 resets
+          map save  → DP1=True,  DP118 climbs 0→100 → DOCKED
+          done      → DP1=False
 
-        Mid-session charge dock: DP1 stays True throughout — no False transition,
-        so _expecting_map_save is never set and a subsequent return shows RETURNING.
+        In-place map save (stop without docking):
+          DP118 drops from ≥5 to 1–4 while DP1 stays True, then climbs back.
 
-        Cancelled session (e.g. sunset): DP1 goes False and stays False.
-        After MAP_SAVE_TIMEOUT_POLLS consecutive False polls we abandon the
-        map-save expectation so the next scheduled mow starts fresh.
+        DP2 (pause/resume) is not tracked here; those cycles have no effect
+        on map-save detection.
         """
         dps = self.coordinator.data or {}
         dp1   = dps.get(DP_TASK_ACTIVE, False)
         dp118 = dps.get(DP_PROGRESS, 0)
+        dp126 = dps.get(DP_AREA, 0)
 
         if dp1:
             self._false_poll_count = 0
 
             if not self._prev_dp1:
-                # DP1 just went True — either a new mow session or map-save start.
+                # DP1 just went True: new mow session or post-dock map save.
                 if self._expecting_map_save:
                     self._in_map_save = True
                     self._expecting_map_save = False
                 else:
                     self._in_map_save = False
                 self._was_returning = False
-
-            if dp118 >= RETURNING_THRESHOLD:
-                self._was_returning = True
+                self._dp1_true_polls = 0
+                self._dp126_confirmed = False
+            else:
+                # DP1 stayed True.
+                self._dp1_true_polls += 1
+                if dp126 != self._prev_dp126:
+                    self._dp126_confirmed = True
+                if dp118 >= RETURNING_THRESHOLD:
+                    self._was_returning = True
+                # In-place map save: DP118 drops from return-range to near-zero
+                # while DP1 never dips False (stop-without-dock sequence).
+                if (self._prev_dp118 >= RETURNING_THRESHOLD
+                        and dp118 < RETURNING_THRESHOLD
+                        and dp118 > 0
+                        and not self._in_map_save):
+                    self._in_map_save = True
+                    self._was_returning = False
 
         else:
             self._false_poll_count += 1
 
             if self._prev_dp1:
-                # DP1 just went False — mower docked after a return trip, OR session
-                # was cancelled.  Only arm map-save expectation if we actually saw a
-                # return trip AND we aren't already in a map-save phase (which would
-                # mean this False is the end of map saving, not the dock-before-save).
-                if self._was_returning and not self._in_map_save:
+                # DP1 just went False: docked after return, map save ended, or cancelled.
+                if self._in_map_save:
+                    # Map saving finished — next DP1 True is a fresh session.
+                    self._expecting_map_save = False
+                elif self._was_returning:
+                    # Completed a return trip and docked; post-dock map save follows.
                     self._expecting_map_save = True
+                # else: cancelled before returning — leave _expecting_map_save alone;
+                # the timeout below clears it if no map save materialises.
                 self._in_map_save = False
                 self._was_returning = False
 
-            # Safety: if DP1 stays False longer than the timeout the session really
-            # ended (e.g. sunset cancel with no map save).  Clear the expectation so
-            # the next session starts clean.
+            # DP1 stayed False past the timeout: session truly ended (e.g. sunset
+            # cancel with no map save).  Clear so the next scheduled mow starts fresh.
             if self._false_poll_count > MAP_SAVE_TIMEOUT_POLLS:
                 self._expecting_map_save = False
 
         self._prev_dp1 = dp1
+        self._prev_dp118 = dp118
+        self._prev_dp126 = dp126
         super()._handle_coordinator_update()
 
     # ── activity ──────────────────────────────────────────────────────────────
@@ -148,23 +174,18 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
         dp2   = dps.get(DP_PAUSED,      False)
         dp118 = dps.get(DP_PROGRESS,    0)
 
-        # Paused: task active but movement stopped
-        if dp1 and dp2:
+        if not dp1:
+            return LawnMowerActivity.DOCKED
+        if dp2:
             return LawnMowerActivity.PAUSED
-
-        if dp1 and not dp2:
-            # DP118 5–99 while not in post-dock map-save phase → physically returning.
-            # _in_map_save suppresses RETURNING when DP118 climbs after a dock event.
-            if RETURNING_THRESHOLD <= dp118 < 100 and not self._in_map_save:
-                try:
-                    return LawnMowerActivity.RETURNING
-                except AttributeError:
-                    return LawnMowerActivity.MOWING
-            if self._in_map_save:
-                return LawnMowerActivity.DOCKED
+        if self._in_map_save:
+            return LawnMowerActivity.DOCKED
+        if RETURNING_THRESHOLD <= dp118 < 100:
+            return LawnMowerActivity.RETURNING
+        # Suppress MOWING during post-session DP1 flickers: DP126 never increments
+        # during flickers but does so every 30–60 s during real mowing.
+        if self._dp126_confirmed or self._dp1_true_polls < 2:
             return LawnMowerActivity.MOWING
-
-        # DP1 absent or False → no active session → docked / idle
         return LawnMowerActivity.DOCKED
 
     # ── commands ──────────────────────────────────────────────────────────────

--- a/custom_components/eufy_robomow/number.py
+++ b/custom_components/eufy_robomow/number.py
@@ -10,11 +10,21 @@ Cloud entities (backed by DP155 via Tuya mobile API):
   • Pad Direction   — DP155 field 4, 0–359°, step 1° (rotary; full rotation)
 
 Path distance is a fixed 3-option select; see select.py.
+
+UNIT DISPLAY: Cut Height and Edge Distance declare NumberDeviceClass.DISTANCE,
+so users can switch the DISPLAYED unit (e.g. inches) per entity in
+HA → entity settings → Unit of measurement.  HA converts display values both
+ways; async_set_native_value always receives NATIVE units (mm / cm), so the
+mm-based cloud write path is unaffected.  The device itself always stores mm.
 """
 
 from __future__ import annotations
 
-from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberMode,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfLength
 from homeassistant.core import HomeAssistant
@@ -70,6 +80,7 @@ class EufyCutHeightNumber(CoordinatorEntity[EufyMowerCoordinator], NumberEntity)
     _attr_has_entity_name = True
     _attr_name = "Cut Height"
     _attr_icon = "mdi:ruler"
+    _attr_device_class = NumberDeviceClass.DISTANCE
     _attr_native_unit_of_measurement = UnitOfLength.MILLIMETERS
     _attr_native_min_value = CUT_HEIGHT_MIN
     _attr_native_max_value = CUT_HEIGHT_MAX
@@ -141,6 +152,7 @@ class EufyEdgeDistanceNumber(CoordinatorEntity[EufyMowerCoordinator], NumberEnti
     _attr_has_entity_name = True
     _attr_name = "Edge Distance"
     _attr_icon = "mdi:border-outside"
+    _attr_device_class = NumberDeviceClass.DISTANCE
     _attr_native_unit_of_measurement = UnitOfLength.CENTIMETERS
     _attr_native_min_value = EDGE_DISTANCE_MIN  # -15 cm
     _attr_native_max_value = EDGE_DISTANCE_MAX  #  15 cm

--- a/custom_components/eufy_robomow/sensor.py
+++ b/custom_components/eufy_robomow/sensor.py
@@ -31,7 +31,8 @@ from .const import (
     DP_PROGRESS,
     DP_TOTAL_TIME,
     DP_SIGNAL,
-    DP_LIVE_VIEW,
+    DP_LAST_NOTIFICATION,
+    DP_ERROR_CODE,
     DP_TASK_ACTIVE,
     GENERIC_SENSOR_PREFIX,
 )
@@ -52,7 +53,8 @@ EXCLUDED_DPS = {
     "101",  # Rain detection   → dedicated Switch entity
     "109",  # Signal strength  → dedicated Sensor entity
     "110",  # Cut height       → dedicated Number entity
-    "114",  # Live view state  → dedicated Sensor entity
+    "114",  # Last notification → dedicated Sensor entity
+    "115",  # Error code        → dedicated Sensor entity
     "113",  # Session telemetry → dedicated EufyMowingProgressSensor + EufySessionDistanceSensor
     "118",  # Return Progress  → dedicated sensor
     "124",  # Coverage         → dedicated EufyCoverageSensor (blob decode)
@@ -140,10 +142,16 @@ SENSORS: tuple[EufySensorDescription, ...] = (
         icon="mdi:signal",
     ),
     EufySensorDescription(
-        key="live_view",
-        dp=DP_LIVE_VIEW,
-        name="Live View State",
-        icon="mdi:camera",
+        key="last_notification",
+        dp=DP_LAST_NOTIFICATION,
+        name="Last Notification",
+        icon="mdi:bell",
+    ),
+    EufySensorDescription(
+        key="error_code",
+        dp=DP_ERROR_CODE,
+        name="Error Code",
+        icon="mdi:alert-circle",
     ),
 )
 


### PR DESCRIPTION
- Added CONF_DEVICE_NAME constant to const.py
- Save device name from cloud discovery into config entry data
- lawn_mower.py now reads device name dynamically instead of hardcoding E15

Tested on E18 — cloud returns 'eufy S1200' (Terramow S1200 hardware). E15 equivalent unknown; falls back to 'Eufy Robomow' if not present.