### PR TITLE
Add safe control mode and live E15 map support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "codex/**"
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.14"
+          cache: pip
+      - name: Install development tools
+        run: python -m pip install --requirement requirements-dev.txt
+      - name: Ruff
+        run: python -m ruff check .
+      - name: Tests
+        run: python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,56 @@ jobs:
         run: python -m pip install --requirement requirements-dev.txt
       - name: Ruff
         run: python -m ruff check .
+      - name: Types
+        run: python -m mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs custom_components/eufy_robomow
       - name: Tests
         run: python -m pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22"
+      - run: node --experimental-default-type=module --test tests/frontend/card.test.mjs
+
+  hassfest:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/home-assistant/hassfest@sha256:5fc3c5d7df109d248a61acfb0a675b38b1e4dc3a202feb260a8e33696f9803e3
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Validate integration
+        run: |
+          cd /usr/src/homeassistant
+          python3 -m script.hassfest --action validate --integration-path "$GITHUB_WORKSPACE/custom_components/eufy_robomow"
+
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.14"
+      - run: python -m pip install 'pip-audit>=2.9,<3'
+      - name: Audit declared runtime dependencies
+        run: |
+          python -c 'import json; print("\n".join(json.load(open("custom_components/eufy_robomow/manifest.json"))["requirements"]))' > /tmp/runtime-requirements.txt
+          python -m pip_audit --requirement /tmp/runtime-requirements.txt
+
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Scan source for secrets
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          asset="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          curl -fsSL "$base/$asset" -o "/tmp/$asset"
+          curl -fsSL "$base/gitleaks_${GITLEAKS_VERSION}_checksums.txt" -o /tmp/checksums.txt
+          (cd /tmp && grep "  $asset\$" checksums.txt | sha256sum --check --strict)
+          tar -xzf "/tmp/$asset" -C /tmp gitleaks
+          /tmp/gitleaks dir --redact --no-banner .

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 # Python
+.venv/
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.coverage
+coverage.xml
 __pycache__/
 *.pyc
 *.pyo
@@ -24,3 +30,12 @@ AGENT_CONTEXT.md
 
 # The key-grabber tool lives in its own repo
 eufy-clean-local-key-grabber/
+
+# Private captures and credentials
+captures/
+*.pcap
+*.pcapng
+.env
+.env.*
+secrets.yaml
+*local_key*

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,33 @@
+title = "Eufy source secret scan"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Synthetic local-key fixtures used only by tests"
+condition = "AND"
+regexTarget = "secret"
+paths = ['''^tests/test_options_flow\.py$''']
+regexes = [
+  '''^0123456789abcdef$''',
+]
+
+[[allowlists]]
+description = "Synthetic local-key fixtures used only by tests"
+condition = "AND"
+regexTarget = "secret"
+paths = ['''^tests/test_map_source\.py$''']
+regexes = [
+  '''^0123456789abcdef$''',
+]
+
+[[allowlists]]
+description = "Inherited vendor application constants; not user credentials"
+condition = "AND"
+regexTarget = "secret"
+paths = ['''^custom_components/eufy_robomow/cloud\.py$''']
+regexes = [
+  '''^GQCpr9dSp3uQpsOMgJ4xQ$''',
+  '''^cepev5pfnhua4dkqkdpmnrdxx378mpjr$''',
+  '''^s8x78u7xwymasd9kqa7a73pjhxqsedaj$''',
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,4 +8,6 @@
 - E15 is the only model that may be claimed as supported until E18 hardware is physically validated.
 - HACS packaging and publication are deferred. Obsidian is out of scope for this project.
 - Run Ruff and pytest for every code change. Add focused regression coverage for confirmed protocol behavior.
+- GitHub is the canonical development source and tracker. Preserve the public map-source API when porting locally validated work; do not publish private deployment history or household entity identifiers.
+- Keep GitHub Actions checks for types, frontend tests, Hassfest, runtime dependency audit and secrets in addition to Ruff and pytest.
 - Do not deploy to the live mower or Home Assistant instance from CI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository operating rules
+
+- This repository is the working GitHub fork for the Eufy E15 Home Assistant integration.
+- Keep changes independent and evidence-based. Do not copy code, fixtures, constants, schemas, or tests from other unlicensed forks.
+- The upstream history currently declares no license. Do not mirror this source to GitLab or publish a release under a new license until licensing is resolved.
+- Default to `observe_only`. Never enable physical commands or settings writes without explicit user opt-in and supervised validation.
+- Never commit or log passwords, tokens, local keys, full device identifiers, exact coordinates, private lawn geometry, or raw unredacted captures.
+- E15 is the only model that may be claimed as supported until E18 hardware is physically validated.
+- HACS packaging and publication are deferred. Obsidian is out of scope for this project.
+- Run Ruff and pytest for every code change. Add focused regression coverage for confirmed protocol behavior.
+- Do not deploy to the live mower or Home Assistant instance from CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+This integration is under private-alpha development even though its working fork is visible on GitHub.
+
+## Development workflow
+
+1. Create a focused branch from `main`.
+2. Use conventional commit messages.
+3. Keep protocol parsing separate from Home Assistant framework glue where practical.
+4. Run `python -m ruff check .` and `python -m pytest` with Python 3.14.
+5. Describe scope, validation, risk, and rollback in the pull request.
+
+## Protocol provenance
+
+Only submit behavior and constants independently reproduced on owned hardware or derived from documentation that permits reuse. Other unlicensed mower integrations may inform a feature checklist, but their source, fixtures, constants, schemas, and tests must not be copied.
+
+Every protocol change must identify its evidence in the pull request. Repeat physical observations three times before marking a field or command confirmed.
+
+## Safety and privacy
+
+Never include passwords, access or refresh tokens, local keys, complete device identifiers, account identifiers, exact coordinates, private lawn geometry, or raw captures. Use synthetic or redacted fixtures.
+
+Physical commands require daylight, a clear lawn, continuous supervision, and known physical stop controls. Do not bypass mower safety interlocks.
+
+## Licensing
+
+The inherited upstream history currently declares no license. Do not add a repository-wide license, mirror this source to another forge, or publish a release under a new license without resolving that boundary.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Home Assistant custom integration for the **Eufy E15** robotic lawn mower. The
 
 Control and monitor your Eufy mower directly from Home Assistant over your local network, with cloud-synced settings pulled straight from your Eufy account — no extra tools or manual key extraction required.
 
+GitHub is the development source and issue tracker for this fork. Version 0.7.0
+adds a dedicated dashboard card, observed session history, confirmed commands
+and an optional Home Assistant planning package.
+
 ---
 
 ## Features
@@ -89,6 +93,43 @@ opt in to control.
 
 > **Alpha credential notice:** the current cloud client still stores the Eufy account password in the Home Assistant config entry so it can renew sessions. Restrict access to Home Assistant backups and `.storage`; replacing this with renewable session material is tracked as a separate hardening change.
 
+### Mower dashboard and session history
+
+1. Install the integration and restart Home Assistant.
+2. Add `/eufy_robomow/eufy-mower-card.js?v=0.7.0` as a JavaScript module under
+   **Settings → Dashboards → Resources** (advanced mode may be needed).
+3. Create a dashboard, enable its sidebar entry, and use
+   [`examples/dashboard.yaml`](examples/dashboard.yaml). Replace entity IDs with
+   those from your installation. The card also works in an existing dashboard.
+
+The card supports map zoom/pan, battery and session telemetry, settings, and
+start/resume, pause and return commands. It shows pending, confirmed, failed and
+uncertain results. Start requires confirmation; unavailable or stale telemetry
+and observe-only mode disable controls. An inactive-task response to Return is
+not proof of physical arrival at the dock.
+
+Fifty observed session summaries are stored privately in Home Assistant; the
+card shows the latest twenty. Pauses and telemetry gaps remain visible, and a
+restart does not invent missing mowing time. Area remains in raw units until the
+scale is validated. Existing lifetime counters are not reconstructed as sessions.
+The optional map source described below is still required for map display.
+
+### Optional rain-aware planning
+
+[`examples/eufy_mower_planning.yaml`](examples/eufy_mower_planning.yaml) is an
+opt-in Home Assistant package. Replace every `example_*` source and mower entity
+with your own. It expects the documented Buienalarm precipitation-array shape
+and separate irrigation valve, active-session, planned-session and start-time
+entities. Missing or stale sources block automatic starts.
+
+The package offers weekday and time-window selection, minimum battery, dry hold
+and maximum session duration. It checks radar coverage for the whole planned
+session, irrigation conflicts, daylight and onboard rain/child protection. It
+allows at most one start attempt per day. Its watchdog handles only sessions it
+started, issuing one pause or return request without automatic retries/resume.
+Automatic mowing initially stays off; configure and supervise validation before
+enabling it. Eufy-app schedules run independently and must be considered separately.
+
 ### Optional read-only map
 
 E15 maps use a separate Tuya P2P media transport that is not available through
@@ -145,7 +186,7 @@ protocol tests.
 
 ## Known limitations
 
-- **Zone mowing** — the local Tuya protocol cannot distinguish zone 1 from zone 2 (both send an identical DP154 value; zone selection happens over cloud MQTT which is not locally accessible). Full-area mow only for now.
+- **Zone mowing** — the owned E15 app shows Entire, Zone, Box and Spot, but area identifiers and command transport have not been validated. No zone action is exposed; see [zone research](docs/zone-control-research.md).
 - **Map acquisition** — experimental and requires a separate compatible source because Tuya publishes the required P2P transport only through its Android media stack.
 - **Live marker semantics** — the live mower/station interpretation matches repeated E15 observations but is not a vendor-documented protocol contract. It is display-only and never drives mower control.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ Pick your mower from the dropdown and enter its local IP address (find it in you
 
 That's it — no external tools, no manual key extraction.
 
-New entries start in **observe-only** mode. In this mode the mower entity reports state, but physical commands and settings-write entities are disabled. After supervised read-only validation, use **Settings → Devices & Services → Eufy Robomow → Configure** to opt in to control.
+New entries start in **observe-only** mode. Entries upgraded from the original
+integration also start in observe-only when they do not yet have an explicit
+operating mode. In this mode the mower entity reports state, but physical
+commands and settings-write entities are disabled. After supervised read-only
+validation, use **Settings → Devices & Services → Eufy Robomow → Configure** to
+opt in to control.
 
 > **Alpha credential notice:** the current cloud client still stores the Eufy account password in the Home Assistant config entry so it can renew sessions. Restrict access to Home Assistant backups and `.storage`; replacing this with renewable session material is tracked as a separate hardening change.
 
@@ -131,12 +136,18 @@ issue or include them in diagnostics.
   `ETag`-aware live pulls while mowing, then renders the validated geometry
   locally as a script-free SVG.
 
+Runtime dependencies are pinned to the versions validated with Home Assistant
+2026.7.1 and the E15's Tuya 3.5 transport. `requests` is declared directly;
+TinyTuya remains pinned to 1.20.0 until another version passes the same local
+protocol tests.
+
 ---
 
 ## Known limitations
 
 - **Zone mowing** — the local Tuya protocol cannot distinguish zone 1 from zone 2 (both send an identical DP154 value; zone selection happens over cloud MQTT which is not locally accessible). Full-area mow only for now.
 - **Map acquisition** — experimental and requires a separate compatible source because Tuya publishes the required P2P transport only through its Android media stack.
+- **Live marker semantics** — the live mower/station interpretation matches repeated E15 observations but is not a vendor-documented protocol contract. It is display-only and never drives mower control.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Eufy Robomow — Home Assistant Integration
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-
-A Home Assistant custom integration for the **Eufy E15** and **E18** robotic lawn mowers.
+A Home Assistant custom integration for the **Eufy E15** robotic lawn mower. The design is capability-driven for possible E18 support, but E18 support is not yet hardware-validated or claimed.
 
 Control and monitor your Eufy mower directly from Home Assistant over your local network, with cloud-synced settings pulled straight from your Eufy account — no extra tools or manual key extraction required.
 
@@ -12,7 +10,7 @@ Control and monitor your Eufy mower directly from Home Assistant over your local
 
 | Entity | Type | Description |
 |--------|------|-------------|
-| Mower | `lawn_mower` | Start, pause, dock — with activity state (mowing / returning / docked / paused) |
+| Mower | `lawn_mower` | Activity state; start, pause, and dock after control is explicitly enabled |
 | Battery | `sensor` | Battery level (%) |
 | Mowed Area | `sensor` | Area covered in the current or last session |
 | Mowing Progress | `sensor` | Real-time session completion % (from DP113 telemetry blob) |
@@ -42,23 +40,18 @@ Control and monitor your Eufy mower directly from Home Assistant over your local
 
 - **Local network access** — the mower and Home Assistant must be on the same LAN (or the mower reachable via IP).
 - **Eufy account** — required for cloud-managed settings. The same email/password you use in the Eufy Home app.
-- HA **2024.1** or newer.
+- Home Assistant **2026.7** or newer during private alpha development.
 
 ---
 
 ## Installation
 
-### Via HACS (recommended)
-
-1. Open HACS → **Integrations** → ⋮ → **Custom repositories**
-2. Add URL: `https://github.com/jnicolaes/eufy-robomow-ha` — category: **Integration**
-3. Search for **Eufy Robomow** and install
-4. Restart Home Assistant
-
-### Manual
+### Private development installation
 
 1. Copy the `custom_components/eufy_robomow/` folder into your HA `config/custom_components/` directory
 2. Restart Home Assistant
+
+HACS packaging is intentionally deferred until the private integration has passed protocol, safety, and reliability validation.
 
 ---
 
@@ -74,13 +67,17 @@ Pick your mower from the dropdown and enter its local IP address (find it in you
 
 That's it — no external tools, no manual key extraction.
 
+New entries start in **observe-only** mode. In this mode the mower entity reports state, but physical commands and settings-write entities are disabled. After supervised read-only validation, use **Settings → Devices & Services → Eufy Robomow → Configure** to opt in to control.
+
+> **Alpha credential notice:** the current cloud client still stores the Eufy account password in the Home Assistant config entry so it can renew sessions. Restrict access to Home Assistant backups and `.storage`; replacing this with renewable session material is tracked as a separate hardening change.
+
 ---
 
 ## How it works
 
 - **Local polling** (every 10 s) via the [Tuya local protocol](https://github.com/jasonacox/tinytuya) for real-time status (battery, activity state, etc.).
 - **Cloud polling** (every 5 min) via the Tuya mobile API for settings stored as protobuf blobs in DP155.
-- **Writes** go directly to the cloud API and are immediately reflected in the Eufy app.
+- **Writes**, when control is explicitly enabled, go to either the local mower or the cloud API depending on the setting.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,17 @@ opt in to control.
 ### Mower dashboard and session history
 
 1. Install the integration and restart Home Assistant.
-2. Add `/eufy_robomow/eufy-mower-card.js?v=0.7.0` as a JavaScript module under
+2. Add `/eufy_robomow/eufy-mower-card.js?v=0.7.1` as a JavaScript module under
    **Settings → Dashboards → Resources** (advanced mode may be needed).
 3. Create a dashboard, enable its sidebar entry, and use
    [`examples/dashboard.yaml`](examples/dashboard.yaml). Replace entity IDs with
-   those from your installation. The card also works in an existing dashboard.
+   those from your installation. The example uses four native Home Assistant tabs:
+   mower, history, planning and settings. Cards follow the active HA theme, like
+   the Eufy Viewer dashboard. The card also works in an existing dashboard.
+
+Set `view` to `overview`, `history`, `planning` or `settings` to show one section.
+Omitting it keeps the combined view for existing cards. Frontend version 0.7.1
+changes presentation only; it does not add zone commands or enable planning.
 
 The card supports map zoom/pan, battery and session telemetry, settings, and
 start/resume, pause and return commands. It shows pending, confirmed, failed and

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Control and monitor your Eufy mower directly from Home Assistant over your local
 | Child Protection | `switch` | Enable child/pet protection mode |
 | Smart No-Go Suggestions | `switch` | AI-assisted no-go zone suggestions |
 | Mow Yellow Grass | `switch` | Allow mowing on dry/yellow grass |
+| Map | `image` | Optional read-only E15 boundary, areas, pathways, mower and cleaning path |
 
 > **Cloud entities** (edge distance, pad direction, speeds, path distance) require your Eufy account credentials. They are polled every 5 minutes and written back via the Tuya mobile API.
 >
@@ -71,6 +72,42 @@ New entries start in **observe-only** mode. In this mode the mower entity report
 
 > **Alpha credential notice:** the current cloud client still stores the Eufy account password in the Home Assistant config entry so it can renew sessions. Restrict access to Home Assistant backups and `.storage`; replacing this with renewable session material is tracked as a separate hardening change.
 
+### Optional read-only map
+
+E15 maps use a separate Tuya P2P media transport that is not available through
+the mower's normal local DPS connection. This integration can consume a
+compatible map source without bundling that transport or its Android-only
+vendor libraries.
+
+Configure the source under **Settings → Devices & Services → Eufy Robomow →
+Configure**:
+
+- **Map source HTTPS URL** — base URL of the map source.
+- **Certificate SHA-256 fingerprint** — optional pin for private or self-signed
+  TLS. Normal certificate validation is used when this is empty.
+
+Authentication is derived from the mower's existing local key; no additional
+token is stored. The source must expose `GET /v1/map` with content type
+`application/vnd.eufy-robomow-map+zip`, support `ETag` responses, and use the
+`X-Eufy-Map-Mode` request header (`idle` or `stream`) to control its read-only
+P2P session. The stored ZIP contains a manifest and exactly these three files:
+
+- `map.bin.stream`
+- `cleanPath.bin.stream`
+- `navPath.bin.stream`
+
+Home Assistant validates the archive, device binding, sizes, hashes, protobuf
+and boundary before displaying it. One latest-good bundle is stored privately
+under `/config/eufy_robomow_maps/`. If acquisition fails, the previous valid map
+remains available. Idle maps refresh every five minutes. During an active mowing
+task, Home Assistant requests changed stream snapshots every two seconds,
+accumulates and deduplicates coverage deltas, and renders the newest mower pose.
+Clear the source URL to remove the map entity; no mower setting or geometry is
+changed.
+
+Map bundles contain private lawn geometry. Never commit them, attach them to an
+issue or include them in diagnostics.
+
 ---
 
 ## How it works
@@ -78,13 +115,16 @@ New entries start in **observe-only** mode. In this mode the mower entity report
 - **Local polling** (every 10 s) via the [Tuya local protocol](https://github.com/jasonacox/tinytuya) for real-time status (battery, activity state, etc.).
 - **Cloud polling** (every 5 min) via the Tuya mobile API for settings stored as protobuf blobs in DP155.
 - **Writes**, when control is explicitly enabled, go to either the local mower or the cloud API depending on the setting.
+- **Optional map acquisition** uses five-minute idle snapshots and two-second
+  `ETag`-aware live pulls while mowing, then renders the validated geometry
+  locally as a script-free SVG.
 
 ---
 
 ## Known limitations
 
 - **Zone mowing** — the local Tuya protocol cannot distinguish zone 1 from zone 2 (both send an identical DP154 value; zone selection happens over cloud MQTT which is not locally accessible). Full-area mow only for now.
-- **Map display** — live GPS map is not yet supported.
+- **Map acquisition** — experimental and requires a separate compatible source because Tuya publishes the required P2P transport only through its Android media stack.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ Control and monitor your Eufy mower directly from Home Assistant over your local
 >
 > Some entities (generic raw DP sensors, map coverage) are **disabled by default** — enable them in HA if you want to explore unconfirmed data points.
 
+### Map preview
+
+<p align="center">
+  <img src="docs/map-preview.svg" alt="Synthetic Eufy E15 map preview showing the boundary, live mowing coverage, mower, charging station, pathway and no-go area" width="480">
+</p>
+
+The map image follows the live mowing session with two-second, change-aware
+updates. It shows the mapped boundary, charging area, external pathways, no-go
+areas, completed mowing lanes and the latest mower position. The preview above
+uses synthetic geometry; no private lawn map or device data is stored in this
+repository.
+
 ---
 
 ## Prerequisites

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security policy
+
+## Current status
+
+This repository is an alpha integration for a physical device. It is not ready for unattended mower control, HACS distribution, or public support claims.
+
+## Reporting a vulnerability
+
+Do not post secrets, private captures, device identifiers, coordinates, or lawn geometry in a public issue. Contact the repository owner privately with a minimal redacted reproduction. If no private channel is available, open an issue containing no sensitive data and ask for a private contact method.
+
+## Sensitive data
+
+Home Assistant config entries currently contain the mower local key and, when cloud support is enabled, the Eufy email and password. Protect Home Assistant `.storage` and backups accordingly. A future credential-lifecycle change must avoid retaining the account password once renewable session material is proven sufficient.
+
+Logs and diagnostics must redact credentials, full identifiers, coordinates, geometry, and raw payload values. Debug logging is not permission to emit sensitive data.
+
+## Physical safety
+
+The integration defaults to `observe_only`. Enable `control` only for supervised testing. Never use this integration to bypass child lock, rain, obstacle, blade, firmware, or other mower safety mechanisms.
+
+Manual driving, map mutation, camera access, firmware updates, reset, deletion, and account administration require separate security reviews and are out of scope for the current release line.

--- a/custom_components/eufy_robomow/__init__.py
+++ b/custom_components/eufy_robomow/__init__.py
@@ -28,12 +28,18 @@ from .coordinator import EufyMowerCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
+    Platform.IMAGE,
     Platform.LAWN_MOWER,
     Platform.SENSOR,
     Platform.NUMBER,
     Platform.SELECT,   # no-op when no cloud client (handled in select.py)
     Platform.SWITCH,
 ]
+
+
+async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload an entry after its optional map source changes."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -67,6 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/custom_components/eufy_robomow/__init__.py
+++ b/custom_components/eufy_robomow/__init__.py
@@ -20,6 +20,8 @@ from .const import (
     CONF_LOCAL_KEY,
     CONF_EUFY_EMAIL,
     CONF_EUFY_PASSWORD,
+    CONF_OPERATING_MODE,
+    DEFAULT_OPERATING_MODE,
 )
 from .coordinator import EufyMowerCoordinator
 
@@ -55,6 +57,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device_id=entry.data[CONF_DEVICE_ID],
         local_key=entry.data[CONF_LOCAL_KEY],
         cloud_client=cloud_client,
+        operating_mode=entry.options.get(
+            CONF_OPERATING_MODE,
+            entry.data.get(CONF_OPERATING_MODE, DEFAULT_OPERATING_MODE),
+        ),
     )
 
     # Initial data fetch — raises ConfigEntryNotReady if the mower is unreachable

--- a/custom_components/eufy_robomow/__init__.py
+++ b/custom_components/eufy_robomow/__init__.py
@@ -37,11 +37,6 @@ PLATFORMS: list[Platform] = [
 ]
 
 
-async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload an entry after its optional map source changes."""
-    await hass.config_entries.async_reload(entry.entry_id)
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Eufy Robomow from a config entry."""
     email    = entry.data.get(CONF_EUFY_EMAIL, "").strip()
@@ -73,7 +68,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-    entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/custom_components/eufy_robomow/__init__.py
+++ b/custom_components/eufy_robomow/__init__.py
@@ -9,10 +9,14 @@ Optional: Eufy account email + password unlock cloud-managed settings
 from __future__ import annotations
 
 import logging
+from pathlib import Path
+
+from homeassistant.components.http import StaticPathConfig
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 
 from .const import (
     DOMAIN,
@@ -24,8 +28,10 @@ from .const import (
     DEFAULT_OPERATING_MODE,
 )
 from .coordinator import EufyMowerCoordinator
+from .sessions import SessionStore
 
 _LOGGER = logging.getLogger(__name__)
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 PLATFORMS: list[Platform] = [
     Platform.IMAGE,
@@ -35,6 +41,20 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,   # no-op when no cloud client (handled in select.py)
     Platform.SWITCH,
 ]
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Serve the bundled card; private maps still use HA's authenticated image proxy."""
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                "/eufy_robomow/eufy-mower-card.js",
+                str(Path(__file__).parent / "frontend" / "eufy-mower-card.js"),
+                False,
+            )
+        ]
+    )
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -50,7 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             password=password,
             device_id=entry.data[CONF_DEVICE_ID],
         )
-        _LOGGER.debug("Cloud client created for device %s", entry.data[CONF_DEVICE_ID])
+        _LOGGER.debug("Cloud client created")
 
     coordinator = EufyMowerCoordinator(
         hass,
@@ -63,6 +83,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data.get(CONF_OPERATING_MODE, DEFAULT_OPERATING_MODE),
         ),
     )
+
+    session_store = SessionStore(hass, entry.entry_id)
+    await session_store.async_load()
+    coordinator.session_store = session_store
 
     # Initial data fetch — raises ConfigEntryNotReady if the mower is unreachable
     await coordinator.async_config_entry_first_refresh()
@@ -77,5 +101,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        if coordinator.session_store:
+            await coordinator.session_store.async_save()
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/custom_components/eufy_robomow/cloud.py
+++ b/custom_components/eufy_robomow/cloud.py
@@ -600,6 +600,9 @@ class EufyCloudClient:
 
     def _tuya_acquire_session(self) -> None:
         """Authenticate with Tuya and store the session ID + regional base URL."""
+        if self._tuya_username is None or self._tuya_country is None:
+            raise TuyaSessionError("Eufy identity is unavailable for Tuya login")
+
         password = _determine_password(self._tuya_username)
 
         # Step 1: get an RSA public key + challenge token

--- a/custom_components/eufy_robomow/cloud.py
+++ b/custom_components/eufy_robomow/cloud.py
@@ -25,6 +25,7 @@ All API calls are synchronous; callers must run them in an executor thread
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import hmac as _hmac_module
 import json
@@ -156,14 +157,16 @@ def _varint_decode(data: bytes, pos: int) -> tuple[int, int]:
     """Decode a varint starting at *pos*. Returns (value, new_pos)."""
     result = 0
     shift = 0
-    while True:
+    for _ in range(10):
+        if pos >= len(data):
+            raise ValueError("Truncated protobuf varint")
         b = data[pos]
         pos += 1
         result |= (b & 0x7F) << shift
         if not (b & 0x80):
-            break
+            return result, pos
         shift += 7
-    return result, pos
+    raise ValueError("Protobuf varint exceeds 10 bytes")
 
 
 def _encode_field(field_num: int, wire_type: int, value: bytes | int) -> bytes:
@@ -223,7 +226,10 @@ def _encode_dp155(
 
 def _decode_dp155(blob: str) -> dict[str, Any]:
     """Decode a DP155 base64 blob and return the four cloud settings."""
-    data = base64.b64decode(blob)
+    try:
+        data = base64.b64decode(blob, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("DP155 is not valid base64") from exc
     pos = 0
     settings: dict[str, Any] = {}
 

--- a/custom_components/eufy_robomow/commands.py
+++ b/custom_components/eufy_robomow/commands.py
@@ -1,0 +1,59 @@
+"""Confirm commands using fresh local telemetry, never cloud or cached values."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import asyncio
+from typing import Any
+
+from homeassistant.util import dt as dt_util
+
+from .const import DP_PAUSED, DP_PROGRESS, DP_TASK_ACTIVE, RETURNING_THRESHOLD
+
+
+def command_evidence(action: str, dps: dict[str, Any]) -> str | None:
+    """Describe exactly what a new device status proves."""
+    active, paused, progress = dps.get(DP_TASK_ACTIVE), dps.get(DP_PAUSED), dps.get(DP_PROGRESS)
+    if action in ("start", "resume"):
+        if active is True and paused is False and progress == 0:
+            return "mowing_reported"
+    elif action == "pause" and active is True and paused is True:
+        return "pause_reported"
+    elif action == "dock":
+        if active is True and isinstance(progress, int) and RETURNING_THRESHOLD <= progress < 100:
+            return "returning_reported"
+        if active is False:
+            # DP1=False proves an inactive task, not physical arrival at the dock.
+            return "task_inactive"
+    return None
+
+
+@dataclass
+class MowerCommand:
+    """One bounded operation; a later safety command may supersede it."""
+
+    action: str
+    after_generation: int
+    sent_monotonic: float = float("inf")
+    state: str = "sending"
+    evidence: str | None = None
+    requested_at: str = field(default_factory=lambda: dt_util.utcnow().isoformat())
+    finished_at: str | None = None
+    event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+
+    def finish(self, state: str, evidence: str | None = None) -> None:
+        self.state, self.evidence = state, evidence
+        self.finished_at = dt_util.utcnow().isoformat()
+        self.event.set()
+
+    def observe(self, generation: int, dps: dict[str, Any]) -> None:
+        if self.state != "pending" or generation <= self.after_generation:
+            return
+        if evidence := command_evidence(self.action, dps):
+            self.finish("confirmed", evidence)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            key: getattr(self, key)
+            for key in ("action", "state", "evidence", "requested_at", "finished_at")
+        }

--- a/custom_components/eufy_robomow/config_flow.py
+++ b/custom_components/eufy_robomow/config_flow.py
@@ -30,10 +30,13 @@ from .const import (
     CONF_LOCAL_KEY,
     CONF_EUFY_EMAIL,
     CONF_EUFY_PASSWORD,
+    CONF_MAP_CERTIFICATE_FINGERPRINT,
+    CONF_MAP_SOURCE_URL,
     CONF_OPERATING_MODE,
     DEFAULT_OPERATING_MODE,
     OPERATING_MODES,
 )
+from .map_source import MapSourceError, MapSourceSettings
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -207,14 +210,27 @@ class EufyRobomowConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class EufyRobomowOptionsFlow(OptionsFlowWithReload):
-    """Manage safety-sensitive integration options."""
+    """Manage operating mode and optional read-only map acquisition."""
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Configure the integration operating mode."""
+        """Configure integration behavior."""
+        errors: dict[str, str] = {}
         if user_input is not None:
-            return self.async_create_entry(data=user_input)
+            try:
+                MapSourceSettings.from_values(
+                    base_url=user_input.get(CONF_MAP_SOURCE_URL, ""),
+                    certificate_fingerprint=user_input.get(
+                        CONF_MAP_CERTIFICATE_FINGERPRINT,
+                        "",
+                    ),
+                    local_key=self.config_entry.data[CONF_LOCAL_KEY],
+                )
+            except MapSourceError:
+                errors["base"] = "invalid_map_source"
+            else:
+                return self.async_create_entry(data=user_input)
 
         current_mode = self.config_entry.options.get(
             CONF_OPERATING_MODE,
@@ -223,13 +239,27 @@ class EufyRobomowOptionsFlow(OptionsFlowWithReload):
         schema = vol.Schema(
             {
                 vol.Required(CONF_OPERATING_MODE): vol.In(OPERATING_MODES),
+                vol.Optional(CONF_MAP_SOURCE_URL): str,
+                vol.Optional(CONF_MAP_CERTIFICATE_FINGERPRINT): str,
             }
         )
+        suggested = {
+            CONF_OPERATING_MODE: current_mode,
+            CONF_MAP_SOURCE_URL: self.config_entry.options.get(
+                CONF_MAP_SOURCE_URL,
+                "",
+            ),
+            CONF_MAP_CERTIFICATE_FINGERPRINT: self.config_entry.options.get(
+                CONF_MAP_CERTIFICATE_FINGERPRINT,
+                "",
+            ),
+        }
+        if user_input is not None:
+            suggested.update(user_input)
         return self.async_show_form(
             step_id="init",
-            data_schema=self.add_suggested_values_to_schema(
-                schema, {CONF_OPERATING_MODE: current_mode}
-            ),
+            data_schema=self.add_suggested_values_to_schema(schema, suggested),
+            errors=errors,
         )
 
 

--- a/custom_components/eufy_robomow/config_flow.py
+++ b/custom_components/eufy_robomow/config_flow.py
@@ -14,8 +14,14 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
 from homeassistant.const import CONF_HOST
+from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
@@ -24,6 +30,9 @@ from .const import (
     CONF_LOCAL_KEY,
     CONF_EUFY_EMAIL,
     CONF_EUFY_PASSWORD,
+    CONF_OPERATING_MODE,
+    DEFAULT_OPERATING_MODE,
+    OPERATING_MODES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -75,6 +84,14 @@ class EufyRobomowConfigFlow(ConfigFlow, domain=DOMAIN):
         self._email:      str        = ""
         self._password:   str        = ""
         self._discovered: list[dict] = []  # Tuya device dicts
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> EufyRobomowOptionsFlow:
+        """Create the options flow."""
+        return EufyRobomowOptionsFlow()
 
     # ── Step 1: credentials ───────────────────────────────────────────────────
 
@@ -172,6 +189,7 @@ class EufyRobomowConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_LOCAL_KEY:     local_key,
                         CONF_EUFY_EMAIL:    self._email,
                         CONF_EUFY_PASSWORD: self._password,
+                        CONF_OPERATING_MODE: DEFAULT_OPERATING_MODE,
                     },
                 )
 
@@ -185,6 +203,33 @@ class EufyRobomowConfigFlow(ConfigFlow, domain=DOMAIN):
             data_schema=self.add_suggested_values_to_schema(step_schema, suggested),
             errors=errors,
             description_placeholders={"device_count": str(len(self._discovered))},
+        )
+
+
+class EufyRobomowOptionsFlow(OptionsFlowWithReload):
+    """Manage safety-sensitive integration options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Configure the integration operating mode."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        current_mode = self.config_entry.options.get(
+            CONF_OPERATING_MODE,
+            self.config_entry.data.get(CONF_OPERATING_MODE, DEFAULT_OPERATING_MODE),
+        )
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_OPERATING_MODE): vol.In(OPERATING_MODES),
+            }
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                schema, {CONF_OPERATING_MODE: current_mode}
+            ),
         )
 
 

--- a/custom_components/eufy_robomow/const.py
+++ b/custom_components/eufy_robomow/const.py
@@ -21,6 +21,8 @@ CONF_DEVICE_ID = "device_id"
 CONF_LOCAL_KEY = "local_key"
 CONF_EUFY_EMAIL = "eufy_email"  # optional — enables cloud settings
 CONF_EUFY_PASSWORD = "eufy_password"  # optional — enables cloud settings
+CONF_MAP_SOURCE_URL = "map_source_url"
+CONF_MAP_CERTIFICATE_FINGERPRINT = "map_certificate_fingerprint"
 CONF_OPERATING_MODE = "operating_mode"
 
 # Physical commands and setting writes are opt-in while the integration is alpha.

--- a/custom_components/eufy_robomow/const.py
+++ b/custom_components/eufy_robomow/const.py
@@ -21,6 +21,13 @@ CONF_DEVICE_ID = "device_id"
 CONF_LOCAL_KEY = "local_key"
 CONF_EUFY_EMAIL = "eufy_email"  # optional — enables cloud settings
 CONF_EUFY_PASSWORD = "eufy_password"  # optional — enables cloud settings
+CONF_OPERATING_MODE = "operating_mode"
+
+# Physical commands and setting writes are opt-in while the integration is alpha.
+OPERATING_MODE_OBSERVE_ONLY = "observe_only"
+OPERATING_MODE_CONTROL = "control"
+OPERATING_MODES = [OPERATING_MODE_OBSERVE_ONLY, OPERATING_MODE_CONTROL]
+DEFAULT_OPERATING_MODE = OPERATING_MODE_OBSERVE_ONLY
 
 # ── Cloud settings poll interval ───────────────────────────────────────────────
 # Cloud settings are fetched at most once every N seconds (much slower than local).

--- a/custom_components/eufy_robomow/coordinator.py
+++ b/custom_components/eufy_robomow/coordinator.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 import tinytuya
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -23,6 +24,7 @@ from .const import (
     CLOUD_TRAVEL_SPEED,
     CLOUD_BLADE_SPEED,
     CLOUD_PAD_DIRECTION,
+    OPERATING_MODE_CONTROL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,6 +52,7 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         device_id: str,
         local_key: str,
         cloud_client=None,  # EufyCloudClient | None  (avoid circular import)
+        operating_mode: str = "observe_only",
     ) -> None:
         super().__init__(
             hass,
@@ -61,6 +64,7 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         self.device_id = device_id
         self.local_key = local_key
         self.cloud_client = cloud_client
+        self.operating_mode = operating_mode
 
         self._device = self._make_device()
         # Use float('-inf') so the first poll always fetches cloud DPS
@@ -75,6 +79,19 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         # Registered by sensor.py so it can add generic sensors on-the-fly.
         # Callbacks receive the current dps dict as their sole argument.
         self._new_dp_callbacks: list = []
+
+    @property
+    def control_enabled(self) -> bool:
+        """Return whether physical and settings writes are explicitly enabled."""
+        return self.operating_mode == OPERATING_MODE_CONTROL
+
+    def _require_control_enabled(self) -> None:
+        """Reject writes while the integration is in its safe default mode."""
+        if not self.control_enabled:
+            raise HomeAssistantError(
+                "Eufy Robomow is in observe-only mode. Enable control in the "
+                "integration options before sending commands."
+            )
 
     def async_add_new_dp_listener(self, callback) -> None:
         """Register *callback(dps)* to be called whenever new DPS keys are discovered.
@@ -148,7 +165,7 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         dps: dict = result.get("dps", {})
         local_dp_keys: set[str] = set(dps.keys())
 
-        _LOGGER.debug("Local DPS update: %s", dps)
+        _LOGGER.debug("Local DPS update received (%d keys)", len(dps))
 
         # ── 2. Cloud DPS + settings (every CLOUD_POLL_INTERVAL seconds) ───────
         # Two guards before attempting a cloud poll:
@@ -232,8 +249,6 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
                 "New DPS discovered: %s",
                 sorted(new_keys, key=_dp_sort_key),
             )
-            for k in sorted(new_keys, key=_dp_sort_key):
-                _LOGGER.info("  DP%s = %r (%s)", k, dps[k], type(dps[k]).__name__)
             # Pass the current full dps dict so callbacks don't read stale data
             for cb in list(self._new_dp_callbacks):
                 cb(dps)
@@ -257,32 +272,37 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
 
     # ── commands ──────────────────────────────────────────────────────────────
 
-    async def async_send_command(self, dp: str, value) -> bool:
-        """Write a single DPS value to the device. Returns True on success."""
+    async def async_send_command(self, dp: str, value) -> None:
+        """Write a single DPS value or raise a visible Home Assistant error."""
+        self._require_control_enabled()
         _LOGGER.debug("Sending command DP %s = %s", dp, value)
         try:
             result = await self.hass.async_add_executor_job(
                 self._device.set_value, int(dp), value
             )
+            if isinstance(result, dict) and "Error" in result:
+                raise HomeAssistantError(
+                    f"Mower rejected command DP {dp}: {result['Error']}"
+                )
             _LOGGER.debug("Command result: %s", result)
             # Immediately refresh state
             await self.async_request_refresh()
-            return True
+        except HomeAssistantError:
+            raise
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.error("Command DP %s = %s failed: %s", dp, value, exc)
-            return False
+            raise HomeAssistantError(f"Mower command DP {dp} failed: {exc}") from exc
 
-    async def async_set_cloud_setting(self, **kwargs) -> bool:
+    async def async_set_cloud_setting(self, **kwargs) -> None:
         """Write one or more cloud settings via the Tuya mobile API.
 
         Keyword arguments: edge_mm, path_mm, travel_speed, blade_speed, pad_direction.
-        Returns True on success.
+        Raises a visible Home Assistant error when the write is not confirmed.
         """
+        self._require_control_enabled()
         if not self.cloud_client:
-            _LOGGER.error(
-                "async_set_cloud_setting called but no cloud client configured"
+            raise HomeAssistantError(
+                "Cloud settings are unavailable because no cloud client is configured."
             )
-            return False
 
         def _do_set() -> None:
             self.cloud_client.set_settings(**kwargs)
@@ -294,7 +314,6 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
             # Force a cloud re-fetch on the next poll cycle
             self._cloud_last_fetch = float("-inf")
             await self.async_request_refresh()
-            return True
         except Exception as exc:  # noqa: BLE001
             exc_str = str(exc)
             if "DEVICE_OFFLINE" in exc_str or "offline" in exc_str.lower():
@@ -304,4 +323,4 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
                 )
             else:
                 _LOGGER.error("Cloud setting update failed: %s", exc)
-            return False
+            raise HomeAssistantError(f"Cloud setting update failed: {exc}") from exc

--- a/custom_components/eufy_robomow/coordinator.py
+++ b/custom_components/eufy_robomow/coordinator.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from datetime import timedelta
+from threading import Lock
+from homeassistant.util import dt as dt_util
+
+from .commands import MowerCommand
+from .sessions import SessionStore
+from .const import CMD_START, CMD_RESUME, CMD_PAUSE, CMD_DOCK
+from datetime import datetime, timedelta
 
 import tinytuya
 
@@ -66,6 +72,12 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         self.cloud_client = cloud_client
         self.operating_mode = operating_mode
 
+        self._device_lock = Lock()
+        self.local_dps: dict = {}
+        self.local_generation = 0
+        self.last_local_update: datetime | None = None
+        self.command: MowerCommand | None = None
+        self.session_store: SessionStore | None = None
         self._device = self._make_device()
         # Use float('-inf') so the first poll always fetches cloud DPS
         self._cloud_last_fetch: float = float("-inf")
@@ -116,6 +128,11 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         d.set_socketPersistent(False)
         return d
 
+    def _device_call(self, method: str, *args):
+        """Serialize worker calls even if an awaiting task is cancelled."""
+        with self._device_lock:
+            return getattr(self._device, method)(*args)
+
     # ── polling ───────────────────────────────────────────────────────────────
 
     async def _async_update_data(self) -> dict:
@@ -135,8 +152,9 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
              register generic sensors immediately.
         """
         # ── 1. Local DPS (every POLL_INTERVAL seconds) ────────────────────────
+        sample_started = time.monotonic()
         try:
-            result = await self.hass.async_add_executor_job(self._device.status)
+            result = await self.hass.async_add_executor_job(self._device_call, "status")
         except Exception as exc:  # noqa: BLE001
             self._consecutive_errors += 1
             if self._consecutive_errors >= _MAX_CONSECUTIVE_ERRORS:
@@ -147,6 +165,9 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
                 self._device = self._make_device()
                 self._consecutive_errors = 0
             raise UpdateFailed(f"Tuya connection error: {exc}") from exc
+
+        if not isinstance(result, dict) or not isinstance(result.get("dps"), dict):
+            raise UpdateFailed("No valid local mower telemetry received")
 
         if "Error" in result:
             err = result["Error"]
@@ -164,6 +185,14 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         self._consecutive_errors = 0
         dps: dict = result.get("dps", {})
         local_dp_keys: set[str] = set(dps.keys())
+        command_pending = self.command and self.command.state in ("sending", "pending")
+        self.local_dps = dict(dps)
+        self.local_generation += 1
+        self.last_local_update = dt_util.utcnow()
+        if self.command and sample_started > self.command.sent_monotonic:
+            self.command.observe(self.local_generation, self.local_dps)
+        if self.session_store:
+            self.session_store.observe(self.local_dps, self.last_local_update)
 
         _LOGGER.debug("Local DPS update received (%d keys)", len(dps))
 
@@ -176,7 +205,9 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
         #      login is not retried every 10 s (which would hammer the Eufy API and
         #      interfere with other integrations sharing the same account).
         now = time.monotonic()
-        if self.cloud_client is not None:
+        if command_pending:
+            self._carry_forward_cloud_data(dps, local_dp_keys)
+        elif self.cloud_client is not None:
             _sun = self.hass.states.get("sun.sun")
             _sun_below_horizon = _sun is not None and _sun.state == "below_horizon"
 
@@ -185,15 +216,13 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
                 self._carry_forward_cloud_data(dps, local_dp_keys)
             else:
                 backoff = min(
-                    CLOUD_POLL_INTERVAL * (2 ** self._cloud_consecutive_failures),
+                    CLOUD_POLL_INTERVAL * (2**self._cloud_consecutive_failures),
                     _CLOUD_MAX_BACKOFF,
                 )
                 if now - self._cloud_last_fetch >= backoff:
                     try:
-                        raw_cloud_dps, cloud_settings = (
-                            await self.hass.async_add_executor_job(
-                                self.cloud_client.get_all_dps
-                            )
+                        raw_cloud_dps, cloud_settings = await self.hass.async_add_executor_job(
+                            self.cloud_client.get_all_dps
                         )
                         # Merge: add every cloud DP that is NOT already in local dps.
                         # Local values take precedence (more real-time).
@@ -218,7 +247,7 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
                     except Exception as exc:  # noqa: BLE001
                         self._cloud_consecutive_failures += 1
                         next_retry = min(
-                            CLOUD_POLL_INTERVAL * (2 ** self._cloud_consecutive_failures),
+                            CLOUD_POLL_INTERVAL * (2**self._cloud_consecutive_failures),
                             _CLOUD_MAX_BACKOFF,
                         )
                         _LOGGER.warning(
@@ -256,9 +285,7 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
 
         return dps
 
-    def _carry_forward_cloud_data(
-        self, dps: dict, local_dp_keys: set[str]
-    ) -> None:
+    def _carry_forward_cloud_data(self, dps: dict, local_dp_keys: set[str]) -> None:
         """Copy all non-local keys from the previous coordinator.data into dps.
 
         This keeps cloud-only DP sensors from going unavailable between cloud polls.
@@ -272,18 +299,70 @@ class EufyMowerCoordinator(DataUpdateCoordinator[dict]):
 
     # ── commands ──────────────────────────────────────────────────────────────
 
+    async def async_send_mower_command(self, action: str, timeout: float = 35) -> None:
+        """Send once, then await fresh device telemetry with a bounded timeout."""
+        self._require_control_enabled()
+        if action not in ("start", "resume", "pause", "dock"):
+            raise HomeAssistantError("Unsupported mower command")
+        if self.command and self.command.state in ("sending", "pending"):
+            if action in ("start", "resume"):
+                raise HomeAssistantError("A mower command is already pending")
+            self.command.finish("superseded")
+        operation = MowerCommand(action, self.local_generation)
+        self.command = operation
+        self.async_update_listeners()
+        dp, value = {
+            "start": CMD_START,
+            "resume": CMD_RESUME,
+            "pause": CMD_PAUSE,
+            "dock": CMD_DOCK,
+        }[action]
+        try:
+            result = await self.hass.async_add_executor_job(
+                self._device_call, "set_value", int(dp), value
+            )
+            if operation.state == "superseded":
+                raise HomeAssistantError("Command superseded by a later safety command")
+            if isinstance(result, dict) and "Error" in result:
+                operation.finish("rejected")
+                raise HomeAssistantError("The mower rejected the command")
+            # Ignore every poll that began before the write finished.
+            operation.after_generation = self.local_generation
+            operation.sent_monotonic = time.monotonic()
+            operation.state = "pending"
+            self.async_update_listeners()
+            async with asyncio.timeout(timeout):
+                await self.async_request_refresh()
+                await operation.event.wait()
+            if operation.state == "superseded":
+                raise HomeAssistantError("Command superseded by a later safety command")
+        except TimeoutError as exc:
+            operation.finish("timeout")
+            raise HomeAssistantError(
+                "Command sent, but the mower did not confirm its state within 35 seconds. "
+                "It may still execute; check the mower before retrying."
+            ) from exc
+        except asyncio.CancelledError:
+            operation.finish("interrupted")
+            raise
+        except HomeAssistantError:
+            raise
+        except Exception as exc:
+            operation.finish("failed")
+            raise HomeAssistantError("Could not send the mower command") from exc
+        finally:
+            self.async_update_listeners()
+
     async def async_send_command(self, dp: str, value) -> None:
         """Write a single DPS value or raise a visible Home Assistant error."""
         self._require_control_enabled()
         _LOGGER.debug("Sending command DP %s = %s", dp, value)
         try:
             result = await self.hass.async_add_executor_job(
-                self._device.set_value, int(dp), value
+                self._device_call, "set_value", int(dp), value
             )
             if isinstance(result, dict) and "Error" in result:
-                raise HomeAssistantError(
-                    f"Mower rejected command DP {dp}: {result['Error']}"
-                )
+                raise HomeAssistantError(f"Mower rejected command DP {dp}: {result['Error']}")
             _LOGGER.debug("Command result: %s", result)
             # Immediately refresh state
             await self.async_request_refresh()

--- a/custom_components/eufy_robomow/frontend/eufy-mower-card.js
+++ b/custom_components/eufy_robomow/frontend/eufy-mower-card.js
@@ -1,0 +1,207 @@
+/* Eufy Mower Card — uses Home Assistant entities and authenticated image proxy. */
+export const CARD_VERSION = "0.7.0";
+const unavailable = new Set(["unknown", "unavailable", ""]);
+export const escapeHTML = (value) => String(value ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+export function ageSeconds(value, now = Date.now()) {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? Math.max(0, (now - parsed) / 1000) : Infinity;
+}
+export function controls(state, now = Date.now()) {
+  const a = state?.attributes ?? {};
+  const fresh = state && !unavailable.has(state.state) && ageSeconds(a.telemetry_updated_at, now) < 45;
+  const writable = a.operating_mode === "control" && fresh;
+  const busy = ["sending", "pending"].includes(a.command?.state);
+  const features = a.supported_features ?? 0;
+  return {
+    start: Boolean(writable && !busy && (features & 1) && ["docked", "paused"].includes(state.state)),
+    pause: Boolean(writable && (features & 2) && ["mowing", "returning"].includes(state.state)),
+    dock: Boolean(writable && (features & 4) && ["mowing", "paused", "returning"].includes(state.state)),
+    writable, fresh,
+  };
+}
+export function mapHealth(image, active, now = Date.now()) {
+  if (!image || unavailable.has(image.state)) return {label: "Kaart niet beschikbaar", kind: "warn"};
+  const a = image.attributes;
+  const stale = ageSeconds(a.acquisition_last_success, now) > (active ? 30 : 660);
+  if (stale || a.acquisition_status !== "healthy") return {label: "Bewaarde kaart · geen actuele verbinding", kind: "warn"};
+  return {label: active ? "Live kaart" : "Laatste kaart", kind: "good"};
+}
+const labels = {docked:"Inactief", mowing:"Aan het maaien", paused:"Gepauzeerd", returning:"Terug naar het laadstation", unavailable:"Geen verbinding", unknown:"Status onbekend", idle:"Geen actieve sessie", charging:"Laadfase tijdens sessie"};
+const commandLabels = {sending:"Opdracht wordt verzonden…", pending:"Verzonden · wachten op de maaier…", timeout:"Geen bevestiging ontvangen. Controleer de maaier voordat je opnieuw probeert.", rejected:"De maaier heeft de opdracht geweigerd.", failed:"Verzenden mislukt. Controleer de verbinding.", interrupted:"Bevestiging onderbroken; controleer de maaier.", superseded:"Vervangen door een volgende opdracht."};
+const evidenceLabels = {mowing_reported:"Maaier meldt maaien", pause_reported:"Pauze bevestigd door de maaier", returning_reported:"Maaier meldt terugkeer", task_inactive:"Maaier meldt een inactieve taak; aankomst bij het laadstation is niet bevestigd."};
+const icon = (name) => `<ha-icon icon="mdi:${name}"></ha-icon>`;
+const stamp = (value) => value && Number.isFinite(Date.parse(value)) ? new Date(value).toLocaleString("nl-NL", {day:"numeric", month:"short", hour:"2-digit", minute:"2-digit"}) : "—";
+const minutes = value => (Number(value) || 0) < 60 ? `${Math.round(Number(value) || 0)} sec` : `${Math.round(Number(value) / 60)} min`;
+const numeric = value => typeof value === "number" && Number.isFinite(value) ? value.toLocaleString("nl-NL", {maximumFractionDigits:1}) : "—";
+const validEntity = value => typeof value === "string" && /^[a-z_]+\.[a-z0-9_]+$/.test(value);
+
+export class EufyMowerCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({mode:"open"});
+    this._zoom = 1;
+    this._localBusy = false;
+  }
+  setConfig(config) {
+    if (!validEntity(config.entity) || !config.entity.startsWith("lawn_mower.")) throw new Error("Kies een lawn_mower-entiteit.");
+    for (const key of ["map", "session", "battery", "progress", "distance", "area", "planner_reason"]) {
+      if (config[key] && !validEntity(config[key])) throw new Error(`Ongeldige entiteit: ${key}`);
+    }
+    if (config.settings && (!Array.isArray(config.settings) || !config.settings.every(validEntity))) throw new Error("Instellingen moeten entiteitnamen zijn.");
+    if (config.planner_entities && (!Array.isArray(config.planner_entities) || !config.planner_entities.every(validEntity))) throw new Error("Planning moet entiteitnamen bevatten.");
+    this.config = {...config};
+    this._renderShell();
+    this._update();
+  }
+  set hass(value) { this._hass = value; this._update(); }
+  connectedCallback() {
+    clearInterval(this._clock);
+    this._clock = setInterval(() => this._update(), 5000);
+    this._update();
+  }
+  disconnectedCallback() { clearInterval(this._clock); }
+  getCardSize() { return 12; }
+  getGridOptions() { return {columns:"full", min_columns:6}; }
+  static getStubConfig(hass) { return {entity:Object.keys(hass.states).find(id => id.startsWith("lawn_mower.")) ?? "lawn_mower.maaier"}; }
+  _set(id, text) { const el = this.shadowRoot.getElementById(id); if (el && el.textContent !== String(text)) el.textContent = text; }
+  _state(key) { return this._hass?.states[this.config[key]]; }
+  _metric(key) {
+    const state = this._state(key);
+    if (!state || unavailable.has(state.state)) return "—";
+    const value = Number(state.state);
+    const unit = state.attributes.unit_of_measurement ?? "";
+    return `${Number.isFinite(value) ? numeric(value) : state.state} ${unit === "units" ? "ruwe eenh." : unit}`.trim();
+  }
+  _renderShell() {
+    this._historySignature = null;
+    this.shadowRoot.innerHTML = `<style>${styles}</style>
+    <ha-card><main>
+      <header><div class="brand">${icon("robot-mower")}<div><p class="eyebrow">TUIN / EUFY E15</p><h1>${escapeHTML(this.config.title || "Grasmaaier")}</h1></div></div><span id="connection" class="badge"></span></header>
+      <div class="layout"><section class="map-section" aria-label="Maaikaart">
+        <div class="map-head"><span id="map-health" class="map-label"></span><span id="map-time"></span></div>
+        <div id="map-viewport"><div id="map-canvas"><img id="map-image" alt="Maaikaart met maaierpositie, laadstation en gemaaide banen" draggable="false"></div><div id="map-empty">${icon("map-outline")}<h2>Je tuin in beeld</h2><p>De kaart verschijnt zodra een gevalideerde momentopname beschikbaar is.</p></div></div>
+        <div class="map-footer"><span>Kaartweergave · alleen lezen</span><div class="zoom"><button data-zoom="out" aria-label="Uitzoomen">−</button><button data-zoom="reset" id="zoom-label" aria-label="Zoom herstellen">100%</button><button data-zoom="in" aria-label="Inzoomen">+</button></div></div>
+      </section><aside>
+        <p class="eyebrow">OP DIT MOMENT</p><h2 id="activity">Status ophalen…</h2><p id="telemetry" class="muted"></p>
+        <div class="metrics"><div><span>Batterij</span><strong id="battery">—</strong></div><div><span id="progress-label">Voortgang</span><strong id="progress">—</strong></div></div>
+        <div class="progress-track" role="progressbar" aria-label="Maaivoortgang" aria-valuemin="0" aria-valuemax="100"><span id="progress-bar"></span></div>
+        <div class="session-metrics"><div><span>Afstand</span><b id="distance">—</b></div><div><span>Oppervlakte*</span><b id="area">—</b></div><div><span>Waargenomen maaitijd</span><b id="duration">—</b></div></div>
+        <p class="footnote">* De schaal naar m² is nog niet gevalideerd.</p>
+        <div class="actions"><button id="start" class="primary" data-command="start_mowing">${icon("play")}<span id="start-label">Maaien</span></button><button id="pause" data-command="pause">${icon("pause")}Pauze</button><button id="dock" data-command="dock">${icon("home-import-outline")}Naar laadstation</button></div>
+        <p id="mode" class="muted"></p><p id="command" role="status" aria-live="polite"></p><p id="error" role="alert"></p>
+      </aside></div>
+      <div class="lower"><section class="panel"><div class="section-heading"><h2>${icon("calendar-clock")}Planning</h2><span class="tag">HOME ASSISTANT</span></div><p id="planner-reason"></p><details id="planner-details"><summary>Planning instellen</summary><div id="planner-settings"></div></details><p class="footnote">Automatische starts volgen alleen de ingeschakelde HA-planning. Een schema in de Eufy-app blijft een afzonderlijke bron.</p></section>
+      <section class="panel"><div class="section-heading"><h2>${icon("tune-variant")}Instellingen</h2></div><p class="muted">Maaihoogte, rijsnelheid en maaipatroon.</p><details id="settings-details"><summary>Instellingen openen</summary><div id="settings"></div></details></section></div>
+      <section class="history panel"><div class="section-heading"><h2>${icon("history")}Maaigeschiedenis</h2><span class="tag">LAATSTE 20 SESSIES</span></div><div id="history"></div><p class="footnote">Tijden beginnen bij de eerste waarneming. Onderbrekingen in de verbinding worden gemarkeerd; een beëindigde taak bewijst niet dat het hele gazon klaar is.</p></section>
+      <footer>EUFY MOWER <span>Home Assistant · ${CARD_VERSION}</span></footer>
+    </main></ha-card>`;
+    this.shadowRoot.querySelectorAll("[data-command]").forEach(button => button.addEventListener("click", () => this._command(button.dataset.command)));
+    this.shadowRoot.querySelectorAll("[data-zoom]").forEach(button => button.addEventListener("click", () => {
+      this._zoom = button.dataset.zoom === "reset" ? 1 : Math.max(1, Math.min(4, this._zoom + (button.dataset.zoom === "in" ? .5 : -.5)));
+      this._applyZoom();
+    }));
+    const viewport = this.shadowRoot.getElementById("map-viewport");
+    viewport.addEventListener("pointerdown", e => {
+      if (this._zoom <= 1) return;
+      viewport.setPointerCapture(e.pointerId);
+      this._drag = {x:e.clientX, y:e.clientY, left:viewport.scrollLeft, top:viewport.scrollTop};
+    });
+    viewport.addEventListener("pointermove", e => { if (this._drag) { viewport.scrollLeft = this._drag.left + this._drag.x - e.clientX; viewport.scrollTop = this._drag.top + this._drag.y - e.clientY; } });
+    for (const type of ["pointerup", "pointercancel", "lostpointercapture"]) viewport.addEventListener(type, () => { this._drag = null; });
+    this.shadowRoot.getElementById("map-image").addEventListener("error", () => { this._set("map-health", "Kaart kon niet geladen worden"); });
+    this._makeEntities("settings", this.config.settings);
+    this._makeEntities("planner-settings", this.config.planner_entities);
+  }
+  _applyZoom() {
+    const canvas = this.shadowRoot.getElementById("map-canvas");
+    canvas.style.width = `${this._zoom * 100}%`;
+    canvas.style.height = `${this._zoom * 100}%`;
+    this.shadowRoot.getElementById("map-viewport").style.touchAction = this._zoom > 1 ? "none" : "pan-y";
+    this._set("zoom-label", `${this._zoom * 100}%`);
+  }
+  async _makeEntities(target, entities) {
+    const container = this.shadowRoot.getElementById(target);
+    if (!entities?.length) { container.textContent = "Geen entiteiten geconfigureerd."; return; }
+    try {
+      const helpers = await window.loadCardHelpers();
+      if (this.shadowRoot.getElementById(target) !== container) return;
+      const card = helpers.createCardElement({type:"entities", entities, show_header_toggle:false});
+      card.hass = this._hass;
+      container.replaceChildren(card);
+    } catch { container.textContent = "Instellingen konden niet worden geladen."; }
+  }
+  _update() {
+    if (!this._hass || !this.config || !this.shadowRoot.getElementById("activity")) return;
+    const mower = this._state("entity");
+    const state = mower?.state ?? "unavailable";
+    const c = controls(mower);
+    const session = this._state("session")?.attributes;
+    const current = session?.current_session;
+    const active = ["mowing", "paused", "returning"].includes(state);
+    this._set("activity", current?.phase === "charging" ? labels.charging : (labels[state] ?? state));
+    this._set("connection", c.fresh ? "● Verbonden" : "○ Geen actuele status");
+    this._set("telemetry", `Status bijgewerkt ${stamp(mower?.attributes.telemetry_updated_at)}`);
+    this._set("battery", this._metric("battery"));
+    this._set("progress-label", current ? "Huidige sessie" : "Laatste sessiemeting");
+    const progress = current ? current.progress : Number(this._state("progress")?.state);
+    this._set("progress", current ? (current.progress == null ? "—" : `${numeric(current.progress)} %`) : this._metric("progress"));
+    this._set("distance", current ? (current.distance_m == null ? "—" : `${numeric(current.distance_m)} m`) : this._metric("distance"));
+    this._set("area", current ? (current.area_raw == null ? "—" : `${numeric(current.area_raw)} ruwe eenh.`) : this._metric("area"));
+    this._set("duration", current ? minutes(current.mowing_seconds) : "—");
+    this.shadowRoot.getElementById("progress-bar").style.width = `${Number.isFinite(progress) ? Math.max(0, Math.min(100, progress)) : 0}%`;
+    const track = this.shadowRoot.querySelector(".progress-track");
+    if (Number.isFinite(progress)) track.setAttribute("aria-valuenow", String(progress)); else track.removeAttribute("aria-valuenow");
+    for (const name of ["start", "pause", "dock"]) this.shadowRoot.getElementById(name).disabled = !c[name] || (name === "start" && this._localBusy);
+    this._set("start-label", state === "paused" ? "Hervatten" : "Maaien");
+    this._set("mode", mower?.attributes.operating_mode === "observe_only" ? "Alleen observeren · bediening uitgeschakeld" : (!c.fresh ? "Bediening wacht op actuele maaierstatus." : "Bediening via de bestaande Eufy-integratie."));
+    const command = mower?.attributes.command;
+    this._set("command", command ? (command.state === "confirmed" ? evidenceLabels[command.evidence] ?? "Nieuwe status ontvangen" : commandLabels[command.state] ?? command.state) : "");
+    const map = this._state("map");
+    const health = mapHealth(map, active);
+    this._set("map-health", health.label);
+    this.shadowRoot.getElementById("map-health").className = `map-label ${health.kind}`;
+    this._set("map-time", stamp(map?.attributes.acquisition_last_success));
+    const image = this.shadowRoot.getElementById("map-image");
+    const picture = map?.attributes.entity_picture;
+    // Use only HA's same-origin image proxy; no arbitrary or credential-bearing external URL.
+    const safePicture = typeof picture === "string" && picture.startsWith("/api/image_proxy/");
+    if (safePicture && image.getAttribute("src") !== picture) image.src = picture;
+    image.hidden = !safePicture;
+    this.shadowRoot.getElementById("map-empty").hidden = Boolean(safePicture);
+    this._set("planner-reason", this._state("planner_reason")?.state ?? "Koppel een planningssensor om regen, beregening en het volgende maaimoment hier te zien.");
+    this.shadowRoot.getElementById("settings-details").hidden = !c.writable;
+    this.shadowRoot.querySelectorAll("hui-entities-card").forEach(card => { card.hass = this._hass; });
+    this._history(session?.recent_sessions ?? []);
+  }
+  _history(rows) {
+    const signature = JSON.stringify(rows);
+    if (signature === this._historySignature) return;
+    this._historySignature = signature;
+    const target = this.shadowRoot.getElementById("history");
+    if (!rows.length) { target.innerHTML = '<div class="empty-history">De volgende maaibeurt verschijnt hier automatisch. Eerdere sessies worden niet gereconstrueerd uit losse tellerstanden.</div>'; return; }
+    target.innerHTML = `<div class="table-scroll"><table><thead><tr><th>Sessie</th><th>Maaitijd</th><th>Afstand</th><th>Oppervlakte*</th><th>Onderbrekingen</th></tr></thead><tbody>${rows.slice(0,20).map(row => `<tr><td><b>${escapeHTML(stamp(row.started_at))}</b><small>${escapeHTML(!row.start_observed || !row.end_observed || row.observation_gap ? "Onvolledige waarneming" : "Taak beëindigd")}</small></td><td>${escapeHTML(minutes(row.mowing_seconds))}</td><td>${escapeHTML(numeric(row.distance_m))} m</td><td>${escapeHTML(numeric(row.area_raw))} ruwe eenh.</td><td>${escapeHTML(row.pause_count)} · ${escapeHTML(minutes(row.paused_seconds))}</td></tr>`).join("")}</tbody></table></div>`;
+  }
+  async _command(service) {
+    const control = {start_mowing:"start", pause:"pause", dock:"dock"}[service];
+    if (!controls(this._state("entity"))[control]) return;
+    if (service === "start_mowing" && !window.confirm("Maaien starten of hervatten? Controleer dat het gazon vrij is en je de maaier kunt stoppen.")) return;
+    this._set("error", "");
+    this._localBusy = true;
+    this._update();
+    try { await this._hass.callService("lawn_mower", service, {entity_id:this.config.entity}); }
+    catch (error) { this._set("error", error.message ?? "De opdracht kon niet worden bevestigd."); }
+    finally { this._localBusy = false; this._update(); }
+  }
+}
+
+const styles = `
+:host{display:block;--ink:#183d32;--muted:#687a70;--paper:#f7f8f3;--line:#dde5dc;--green:#276449;font-family:var(--primary-font-family,system-ui,sans-serif);color:var(--ink)}
+*{box-sizing:border-box}ha-card{display:block;background:var(--paper);border:1px solid var(--line);border-radius:24px;overflow:hidden;color:var(--ink)}main{padding:30px}header,.brand,.section-heading,.map-head,.map-footer,footer{display:flex;align-items:center;justify-content:space-between;gap:16px}.brand{justify-content:flex-start}.brand>ha-icon{--mdc-icon-size:34px;background:#e4ebdf;width:60px;height:60px;border-radius:18px;display:grid;place-items:center}.eyebrow{font-size:10px;letter-spacing:2px;font-weight:700;margin:0 0 8px;color:var(--muted)}h1{font-size:30px;font-weight:650;letter-spacing:-1px;margin:0}h2{font-size:19px;letter-spacing:-.4px;font-weight:600;margin:0}p{line-height:1.55}.badge,.tag{font-size:11px;letter-spacing:.3px;border:1px solid var(--line);border-radius:20px;padding:8px 12px;white-space:nowrap}.layout{display:grid;grid-template-columns:minmax(0,1.8fr) minmax(285px,1fr);gap:30px;margin:30px 0}.map-section{background:#edf1e8;border:1px solid var(--line);border-radius:18px;overflow:hidden;min-width:0;display:flex;flex-direction:column}.map-head,.map-footer{font-size:11px;padding:16px 18px;color:var(--muted)}.map-label:before{content:'●';margin-right:7px;color:#588965}.map-label.warn:before{color:#b87b26}.map-head>span:last-child{font-size:10px}#map-viewport{height:410px;position:relative;overflow:auto;flex:1;min-height:300px;cursor:grab}#map-viewport:active{cursor:grabbing}#map-canvas{width:100%;height:100%;min-height:100%}#map-image{width:100%;height:100%;object-fit:contain;display:block}#map-image[hidden],#map-empty[hidden]{display:none}#map-empty{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:30px;color:var(--muted)}#map-empty ha-icon{--mdc-icon-size:48px;margin-bottom:20px}#map-empty p{font-size:13px;max-width:300px}button{font:inherit;cursor:pointer;border:1px solid var(--line);border-radius:10px;background:#fff;color:var(--ink);padding:11px 14px;display:inline-flex;gap:8px;align-items:center;justify-content:center;min-height:44px}button:hover:not(:disabled){background:#e8eee3}button:disabled{opacity:.42;cursor:not-allowed}button:focus-visible,summary:focus-visible{outline:3px solid #619777;outline-offset:3px}.zoom{display:flex;gap:5px}.zoom button{padding:5px 12px;min-height:34px}.zoom button:nth-child(2){font-size:11px;min-width:54px}aside{padding:12px 0}aside>h2{font-size:28px;line-height:1.15;margin:12px 0}.muted{font-size:12px;color:var(--muted)}.metrics{display:grid;grid-template-columns:1fr 1fr;gap:15px;margin-top:26px}.metrics span,.session-metrics span{display:block;color:var(--muted);font-size:12px;margin-bottom:8px}.metrics strong{font-size:28px;letter-spacing:-.7px;font-weight:550}.progress-track{height:5px;border-radius:10px;background:#e0e7da;margin:20px 0 26px;overflow:hidden}.progress-track span{display:block;height:100%;background:#74955d;transition:width .4s}.session-metrics{display:flex;flex-wrap:wrap;gap:20px;justify-content:space-between}.session-metrics b{font-size:14px;font-weight:550}.footnote{font-size:10px;color:var(--muted);line-height:1.5}.actions{display:grid;grid-template-columns:1fr 1fr;gap:9px;margin-top:23px}.actions button:last-child{grid-column:1/-1}.actions .primary{background:var(--green);color:white;border-color:var(--green)}.actions .primary:hover:not(:disabled){background:#184932}.actions ha-icon{--mdc-icon-size:19px}#command{font-size:12px;color:var(--green);margin-bottom:0}#error{font-size:12px;color:#9b402c}.lower{display:grid;grid-template-columns:1fr 1fr;gap:20px}.panel{border:1px solid var(--line);border-radius:16px;padding:22px;background:#ffffff80;min-width:0}.section-heading{margin-bottom:16px}.section-heading h2{display:flex;align-items:center;gap:9px;font-size:16px}.section-heading ha-icon{--mdc-icon-size:19px}.tag{font-size:8px;padding:5px 8px;color:var(--muted)}#planner-reason{font-size:14px}details{border-top:1px solid var(--line);margin-top:18px}summary{font-size:12px;cursor:pointer;padding:15px 0;color:var(--green)}.history{margin-top:20px}.empty-history{padding:24px 0;color:var(--muted);font-size:13px}.table-scroll{overflow:auto}table{width:100%;text-align:left;border-collapse:collapse;font-size:12px;white-space:nowrap}th{font-size:10px;color:var(--muted);font-weight:500;padding:10px 14px 10px 0}td{padding:14px 14px 14px 0;border-top:1px solid var(--line)}td small{display:block;color:var(--muted);margin-top:4px;font-size:10px}footer{margin-top:24px;font-size:9px;letter-spacing:1.2px;color:var(--muted)}footer span{letter-spacing:0}
+@media(min-width:1400px){main{padding:40px}.layout{gap:40px}#map-viewport{height:500px}}
+@media(max-width:800px){main{padding:20px}.layout{grid-template-columns:1fr;gap:16px;margin-top:22px}.lower{grid-template-columns:1fr}#map-viewport{height:330px;min-height:330px}aside{padding:4px}.metrics{margin-top:18px}.map-head{flex-wrap:wrap}.badge{font-size:9px;padding:7px}.brand>ha-icon{width:45px;height:45px;--mdc-icon-size:28px}h1{font-size:25px}.panel{padding:18px}aside>h2{font-size:25px}.map-footer{padding:12px}.footnote{font-size:11px}}
+@media(prefers-color-scheme:dark){:host{--ink:#e1ede0;--muted:#a0b1a4;--paper:#18241e;--line:#344b3c;--green:#58845d}ha-card{color:var(--ink)}.brand>ha-icon,.map-section{background:#233227}.panel{background:#203026}button{background:#2b3e2e;color:var(--ink)}button:hover:not(:disabled){background:#3a5340}.progress-track{background:#344b3c}#command{color:#b1d8a4}#error{color:#ffb59f}}
+`;
+
+if (!customElements.get("eufy-mower-card")) customElements.define("eufy-mower-card", EufyMowerCard);
+window.customCards = window.customCards || [];
+window.customCards.push({type:"eufy-mower-card", name:"Eufy Mower", description:"Kaart, bediening, planning en sessiegeschiedenis voor Eufy Robomow", preview:true});

--- a/custom_components/eufy_robomow/frontend/eufy-mower-card.js
+++ b/custom_components/eufy_robomow/frontend/eufy-mower-card.js
@@ -1,5 +1,5 @@
 /* Eufy Mower Card — uses Home Assistant entities and authenticated image proxy. */
-export const CARD_VERSION = "0.7.0";
+export const CARD_VERSION = "0.7.1";
 const unavailable = new Set(["unknown", "unavailable", ""]);
 export const escapeHTML = (value) => String(value ?? "").replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
 export function ageSeconds(value, now = Date.now()) {
@@ -35,6 +35,11 @@ const minutes = value => (Number(value) || 0) < 60 ? `${Math.round(Number(value)
 const numeric = value => typeof value === "number" && Number.isFinite(value) ? value.toLocaleString("nl-NL", {maximumFractionDigits:1}) : "—";
 const validEntity = value => typeof value === "string" && /^[a-z_]+\.[a-z0-9_]+$/.test(value);
 
+export function cardView(value = "all") {
+  if (!["all", "overview", "history", "planning", "settings"].includes(value)) throw new Error("Onbekende paneelweergave.");
+  return value;
+}
+
 export class EufyMowerCard extends HTMLElement {
   constructor() {
     super();
@@ -49,7 +54,8 @@ export class EufyMowerCard extends HTMLElement {
     }
     if (config.settings && (!Array.isArray(config.settings) || !config.settings.every(validEntity))) throw new Error("Instellingen moeten entiteitnamen zijn.");
     if (config.planner_entities && (!Array.isArray(config.planner_entities) || !config.planner_entities.every(validEntity))) throw new Error("Planning moet entiteitnamen bevatten.");
-    this.config = {...config};
+    this.config = {...config, view:cardView(config.view)};
+    this.dataset.view = this.config.view;
     this._renderShell();
     this._update();
   }
@@ -77,24 +83,30 @@ export class EufyMowerCard extends HTMLElement {
     this.shadowRoot.innerHTML = `<style>${styles}</style>
     <ha-card><main>
       <header><div class="brand">${icon("robot-mower")}<div><p class="eyebrow">TUIN / EUFY E15</p><h1>${escapeHTML(this.config.title || "Grasmaaier")}</h1></div></div><span id="connection" class="badge"></span></header>
-      <div class="layout"><section class="map-section" aria-label="Maaikaart">
+      <div class="layout" data-section="overview"><section class="map-section" aria-label="Maaikaart">
         <div class="map-head"><span id="map-health" class="map-label"></span><span id="map-time"></span></div>
         <div id="map-viewport"><div id="map-canvas"><img id="map-image" alt="Maaikaart met maaierpositie, laadstation en gemaaide banen" draggable="false"></div><div id="map-empty">${icon("map-outline")}<h2>Je tuin in beeld</h2><p>De kaart verschijnt zodra een gevalideerde momentopname beschikbaar is.</p></div></div>
-        <div class="map-footer"><span>Kaartweergave · alleen lezen</span><div class="zoom"><button data-zoom="out" aria-label="Uitzoomen">−</button><button data-zoom="reset" id="zoom-label" aria-label="Zoom herstellen">100%</button><button data-zoom="in" aria-label="Inzoomen">+</button></div></div>
+        <div class="map-footer"><div><h2>${escapeHTML(this.config.title || "Grasmaaier")}</h2><span>Kaart en maaierpositie</span></div><div class="zoom"><button data-zoom="out" aria-label="Uitzoomen">−</button><button data-zoom="reset" id="zoom-label" aria-label="Zoom herstellen">100%</button><button data-zoom="in" aria-label="Inzoomen">+</button></div></div>
       </section><aside>
-        <p class="eyebrow">OP DIT MOMENT</p><h2 id="activity">Status ophalen…</h2><p id="telemetry" class="muted"></p>
+        <div class="aside-top"><span>Status</span><span id="connection-status" class="badge"></span></div><h2 id="activity">Status ophalen…</h2><p id="telemetry" class="muted"></p><div class="actions"><button id="start" class="primary" data-command="start_mowing">${icon("play")}<span id="start-label">Maaien</span></button><button id="pause" data-command="pause">${icon("pause")}Pauze</button><button id="dock" data-command="dock">${icon("home-import-outline")}Naar laadstation</button></div>
         <div class="metrics"><div><span>Batterij</span><strong id="battery">—</strong></div><div><span id="progress-label">Voortgang</span><strong id="progress">—</strong></div></div>
         <div class="progress-track" role="progressbar" aria-label="Maaivoortgang" aria-valuemin="0" aria-valuemax="100"><span id="progress-bar"></span></div>
         <div class="session-metrics"><div><span>Afstand</span><b id="distance">—</b></div><div><span>Oppervlakte*</span><b id="area">—</b></div><div><span>Waargenomen maaitijd</span><b id="duration">—</b></div></div>
         <p class="footnote">* De schaal naar m² is nog niet gevalideerd.</p>
-        <div class="actions"><button id="start" class="primary" data-command="start_mowing">${icon("play")}<span id="start-label">Maaien</span></button><button id="pause" data-command="pause">${icon("pause")}Pauze</button><button id="dock" data-command="dock">${icon("home-import-outline")}Naar laadstation</button></div>
+
         <p id="mode" class="muted"></p><p id="command" role="status" aria-live="polite"></p><p id="error" role="alert"></p>
       </aside></div>
-      <div class="lower"><section class="panel"><div class="section-heading"><h2>${icon("calendar-clock")}Planning</h2><span class="tag">HOME ASSISTANT</span></div><p id="planner-reason"></p><details id="planner-details"><summary>Planning instellen</summary><div id="planner-settings"></div></details><p class="footnote">Automatische starts volgen alleen de ingeschakelde HA-planning. Een schema in de Eufy-app blijft een afzonderlijke bron.</p></section>
-      <section class="panel"><div class="section-heading"><h2>${icon("tune-variant")}Instellingen</h2></div><p class="muted">Maaihoogte, rijsnelheid en maaipatroon.</p><details id="settings-details"><summary>Instellingen openen</summary><div id="settings"></div></details></section></div>
-      <section class="history panel"><div class="section-heading"><h2>${icon("history")}Maaigeschiedenis</h2><span class="tag">LAATSTE 20 SESSIES</span></div><div id="history"></div><p class="footnote">Tijden beginnen bij de eerste waarneming. Onderbrekingen in de verbinding worden gemarkeerd; een beëindigde taak bewijst niet dat het hele gazon klaar is.</p></section>
+      <div class="lower"><section class="panel" data-section="planning"><div class="section-heading"><h2>${icon("calendar-clock")}Planning</h2><span class="tag">HOME ASSISTANT</span></div><p id="planner-reason"></p><details id="planner-details"><summary>Planning instellen</summary><div id="planner-settings"></div></details><p class="footnote">Automatische starts volgen alleen de ingeschakelde HA-planning. Een schema in de Eufy-app blijft een afzonderlijke bron.</p></section>
+      <section class="panel" data-section="settings"><div class="section-heading"><h2>${icon("tune-variant")}Instellingen</h2></div><p class="muted">Maaihoogte, rijsnelheid en maaipatroon.</p><p id="settings-status" class="muted" role="status"></p><details id="settings-details"><summary>Instellingen openen</summary><div id="settings"></div></details></section></div>
+      <section class="history panel" data-section="history"><div class="section-heading"><h2>${icon("history")}Maaigeschiedenis</h2><span class="tag">LAATSTE 20 SESSIES</span></div><div id="history"></div><p class="footnote">Tijden beginnen bij de eerste waarneming. Onderbrekingen in de verbinding worden gemarkeerd; een beëindigde taak bewijst niet dat het hele gazon klaar is.</p></section>
       <footer>EUFY MOWER <span>Home Assistant · ${CARD_VERSION}</span></footer>
     </main></ha-card>`;
+    this.shadowRoot.querySelectorAll("[data-section]").forEach(section => {
+      section.hidden = this.config.view !== "all" && section.dataset.section !== this.config.view;
+    });
+    this.shadowRoot.querySelector(".lower").hidden = !["all", "planning", "settings"].includes(this.config.view);
+    this.shadowRoot.getElementById("planner-details").open = this.config.view === "planning";
+    this.shadowRoot.getElementById("settings-details").open = this.config.view === "settings";
     this.shadowRoot.querySelectorAll("[data-command]").forEach(button => button.addEventListener("click", () => this._command(button.dataset.command)));
     this.shadowRoot.querySelectorAll("[data-zoom]").forEach(button => button.addEventListener("click", () => {
       this._zoom = button.dataset.zoom === "reset" ? 1 : Math.max(1, Math.min(4, this._zoom + (button.dataset.zoom === "in" ? .5 : -.5)));
@@ -109,8 +121,8 @@ export class EufyMowerCard extends HTMLElement {
     viewport.addEventListener("pointermove", e => { if (this._drag) { viewport.scrollLeft = this._drag.left + this._drag.x - e.clientX; viewport.scrollTop = this._drag.top + this._drag.y - e.clientY; } });
     for (const type of ["pointerup", "pointercancel", "lostpointercapture"]) viewport.addEventListener(type, () => { this._drag = null; });
     this.shadowRoot.getElementById("map-image").addEventListener("error", () => { this._set("map-health", "Kaart kon niet geladen worden"); });
-    this._makeEntities("settings", this.config.settings);
-    this._makeEntities("planner-settings", this.config.planner_entities);
+    if (["all", "settings"].includes(this.config.view)) this._makeEntities("settings", this.config.settings);
+    if (["all", "planning"].includes(this.config.view)) this._makeEntities("planner-settings", this.config.planner_entities);
   }
   _applyZoom() {
     const canvas = this.shadowRoot.getElementById("map-canvas");
@@ -125,7 +137,12 @@ export class EufyMowerCard extends HTMLElement {
     try {
       const helpers = await window.loadCardHelpers();
       if (this.shadowRoot.getElementById(target) !== container) return;
-      const card = helpers.createCardElement({type:"entities", entities, show_header_toggle:false});
+      const settingNames = {cut_height:"Maaihoogte", travel_speed:"Rijsnelheid", blade_speed:"Messnelheid", path_distance:"Baanafstand", pad_direction:"Maairichting"};
+      const rows = target === "settings" ? entities.map(entity => {
+        const suffix = Object.keys(settingNames).find(key => entity.endsWith(`_${key}`));
+        return suffix ? {entity, name:settingNames[suffix]} : entity;
+      }) : entities;
+      const card = helpers.createCardElement({type:"entities", entities:rows, show_header_toggle:false});
       card.hass = this._hass;
       container.replaceChildren(card);
     } catch { container.textContent = "Instellingen konden niet worden geladen."; }
@@ -153,7 +170,9 @@ export class EufyMowerCard extends HTMLElement {
     if (Number.isFinite(progress)) track.setAttribute("aria-valuenow", String(progress)); else track.removeAttribute("aria-valuenow");
     for (const name of ["start", "pause", "dock"]) this.shadowRoot.getElementById(name).disabled = !c[name] || (name === "start" && this._localBusy);
     this._set("start-label", state === "paused" ? "Hervatten" : "Maaien");
-    this._set("mode", mower?.attributes.operating_mode === "observe_only" ? "Alleen observeren · bediening uitgeschakeld" : (!c.fresh ? "Bediening wacht op actuele maaierstatus." : "Bediening via de bestaande Eufy-integratie."));
+    this._set("mode", mower?.attributes.operating_mode === "observe_only" ? "Alleen observeren · bediening uitgeschakeld" : (!c.fresh ? "Bediening wacht op actuele maaierstatus." : ""));
+    this._set("connection-status", c.fresh ? "Verbonden" : "Geen actuele status");
+    this._set("settings-status", c.writable ? "" : "Instellingen zijn beschikbaar zodra bediening is ingeschakeld en de maaierstatus actueel is.");
     const command = mower?.attributes.command;
     this._set("command", command ? (command.state === "confirmed" ? evidenceLabels[command.evidence] ?? "Nieuwe status ontvangen" : commandLabels[command.state] ?? command.state) : "");
     const map = this._state("map");
@@ -164,7 +183,7 @@ export class EufyMowerCard extends HTMLElement {
     const image = this.shadowRoot.getElementById("map-image");
     const picture = map?.attributes.entity_picture;
     // Use only HA's same-origin image proxy; no arbitrary or credential-bearing external URL.
-    const safePicture = typeof picture === "string" && picture.startsWith("/api/image_proxy/");
+    const safePicture = ["all", "overview"].includes(this.config.view) && typeof picture === "string" && picture.startsWith("/api/image_proxy/");
     if (safePicture && image.getAttribute("src") !== picture) image.src = picture;
     image.hidden = !safePicture;
     this.shadowRoot.getElementById("map-empty").hidden = Boolean(safePicture);
@@ -195,11 +214,18 @@ export class EufyMowerCard extends HTMLElement {
 }
 
 const styles = `
-:host{display:block;--ink:#183d32;--muted:#687a70;--paper:#f7f8f3;--line:#dde5dc;--green:#276449;font-family:var(--primary-font-family,system-ui,sans-serif);color:var(--ink)}
-*{box-sizing:border-box}ha-card{display:block;background:var(--paper);border:1px solid var(--line);border-radius:24px;overflow:hidden;color:var(--ink)}main{padding:30px}header,.brand,.section-heading,.map-head,.map-footer,footer{display:flex;align-items:center;justify-content:space-between;gap:16px}.brand{justify-content:flex-start}.brand>ha-icon{--mdc-icon-size:34px;background:#e4ebdf;width:60px;height:60px;border-radius:18px;display:grid;place-items:center}.eyebrow{font-size:10px;letter-spacing:2px;font-weight:700;margin:0 0 8px;color:var(--muted)}h1{font-size:30px;font-weight:650;letter-spacing:-1px;margin:0}h2{font-size:19px;letter-spacing:-.4px;font-weight:600;margin:0}p{line-height:1.55}.badge,.tag{font-size:11px;letter-spacing:.3px;border:1px solid var(--line);border-radius:20px;padding:8px 12px;white-space:nowrap}.layout{display:grid;grid-template-columns:minmax(0,1.8fr) minmax(285px,1fr);gap:30px;margin:30px 0}.map-section{background:#edf1e8;border:1px solid var(--line);border-radius:18px;overflow:hidden;min-width:0;display:flex;flex-direction:column}.map-head,.map-footer{font-size:11px;padding:16px 18px;color:var(--muted)}.map-label:before{content:'●';margin-right:7px;color:#588965}.map-label.warn:before{color:#b87b26}.map-head>span:last-child{font-size:10px}#map-viewport{height:410px;position:relative;overflow:auto;flex:1;min-height:300px;cursor:grab}#map-viewport:active{cursor:grabbing}#map-canvas{width:100%;height:100%;min-height:100%}#map-image{width:100%;height:100%;object-fit:contain;display:block}#map-image[hidden],#map-empty[hidden]{display:none}#map-empty{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:30px;color:var(--muted)}#map-empty ha-icon{--mdc-icon-size:48px;margin-bottom:20px}#map-empty p{font-size:13px;max-width:300px}button{font:inherit;cursor:pointer;border:1px solid var(--line);border-radius:10px;background:#fff;color:var(--ink);padding:11px 14px;display:inline-flex;gap:8px;align-items:center;justify-content:center;min-height:44px}button:hover:not(:disabled){background:#e8eee3}button:disabled{opacity:.42;cursor:not-allowed}button:focus-visible,summary:focus-visible{outline:3px solid #619777;outline-offset:3px}.zoom{display:flex;gap:5px}.zoom button{padding:5px 12px;min-height:34px}.zoom button:nth-child(2){font-size:11px;min-width:54px}aside{padding:12px 0}aside>h2{font-size:28px;line-height:1.15;margin:12px 0}.muted{font-size:12px;color:var(--muted)}.metrics{display:grid;grid-template-columns:1fr 1fr;gap:15px;margin-top:26px}.metrics span,.session-metrics span{display:block;color:var(--muted);font-size:12px;margin-bottom:8px}.metrics strong{font-size:28px;letter-spacing:-.7px;font-weight:550}.progress-track{height:5px;border-radius:10px;background:#e0e7da;margin:20px 0 26px;overflow:hidden}.progress-track span{display:block;height:100%;background:#74955d;transition:width .4s}.session-metrics{display:flex;flex-wrap:wrap;gap:20px;justify-content:space-between}.session-metrics b{font-size:14px;font-weight:550}.footnote{font-size:10px;color:var(--muted);line-height:1.5}.actions{display:grid;grid-template-columns:1fr 1fr;gap:9px;margin-top:23px}.actions button:last-child{grid-column:1/-1}.actions .primary{background:var(--green);color:white;border-color:var(--green)}.actions .primary:hover:not(:disabled){background:#184932}.actions ha-icon{--mdc-icon-size:19px}#command{font-size:12px;color:var(--green);margin-bottom:0}#error{font-size:12px;color:#9b402c}.lower{display:grid;grid-template-columns:1fr 1fr;gap:20px}.panel{border:1px solid var(--line);border-radius:16px;padding:22px;background:#ffffff80;min-width:0}.section-heading{margin-bottom:16px}.section-heading h2{display:flex;align-items:center;gap:9px;font-size:16px}.section-heading ha-icon{--mdc-icon-size:19px}.tag{font-size:8px;padding:5px 8px;color:var(--muted)}#planner-reason{font-size:14px}details{border-top:1px solid var(--line);margin-top:18px}summary{font-size:12px;cursor:pointer;padding:15px 0;color:var(--green)}.history{margin-top:20px}.empty-history{padding:24px 0;color:var(--muted);font-size:13px}.table-scroll{overflow:auto}table{width:100%;text-align:left;border-collapse:collapse;font-size:12px;white-space:nowrap}th{font-size:10px;color:var(--muted);font-weight:500;padding:10px 14px 10px 0}td{padding:14px 14px 14px 0;border-top:1px solid var(--line)}td small{display:block;color:var(--muted);margin-top:4px;font-size:10px}footer{margin-top:24px;font-size:9px;letter-spacing:1.2px;color:var(--muted)}footer span{letter-spacing:0}
-@media(min-width:1400px){main{padding:40px}.layout{gap:40px}#map-viewport{height:500px}}
-@media(max-width:800px){main{padding:20px}.layout{grid-template-columns:1fr;gap:16px;margin-top:22px}.lower{grid-template-columns:1fr}#map-viewport{height:330px;min-height:330px}aside{padding:4px}.metrics{margin-top:18px}.map-head{flex-wrap:wrap}.badge{font-size:9px;padding:7px}.brand>ha-icon{width:45px;height:45px;--mdc-icon-size:28px}h1{font-size:25px}.panel{padding:18px}aside>h2{font-size:25px}.map-footer{padding:12px}.footnote{font-size:11px}}
-@media(prefers-color-scheme:dark){:host{--ink:#e1ede0;--muted:#a0b1a4;--paper:#18241e;--line:#344b3c;--green:#58845d}ha-card{color:var(--ink)}.brand>ha-icon,.map-section{background:#233227}.panel{background:#203026}button{background:#2b3e2e;color:var(--ink)}button:hover:not(:disabled){background:#3a5340}.progress-track{background:#344b3c}#command{color:#b1d8a4}#error{color:#ffb59f}}
+:host{display:block;min-width:0;--ink:var(--primary-text-color,#212121);--muted:var(--secondary-text-color,#727272);--paper:var(--ha-card-background,var(--card-background-color,#fff));--line:var(--ha-card-border-color,var(--divider-color,#ddd));--accent:var(--primary-color,#03a9f4);font-family:var(--primary-font-family,system-ui,sans-serif);color:var(--ink)}
+*{box-sizing:border-box}[hidden]{display:none!important}ha-card{display:block;background:transparent;border:0;box-shadow:none;color:var(--ink)}main{padding:8px;max-width:1600px;margin:auto}
+header,.brand,.section-heading,.map-head,.map-footer,.aside-top{display:flex;align-items:center;justify-content:space-between;gap:12px}header{padding:16px 8px}.brand{justify-content:flex-start}.brand>ha-icon{--mdc-icon-size:28px}.eyebrow,footer{display:none}:host(:not([data-view="all"])) header{display:none}
+h1{font-size:24px;margin:0;font-weight:500}h2{font-size:20px;margin:0;font-weight:500}p{line-height:1.5}.badge,.tag{font-size:12px;color:var(--muted);white-space:nowrap}.badge:before{content:'●';font-size:10px;color:var(--accent);margin-right:7px}
+.layout{display:grid;grid-template-columns:minmax(0,1.65fr) minmax(300px,1fr);gap:8px;align-items:start}.map-section,aside,.panel{border:1px solid var(--line);border-radius:16px;overflow:hidden;background:var(--paper);min-width:0}
+.map-section{display:flex;flex-direction:column}.map-head{font-size:12px;padding:12px 16px;color:var(--muted)}.map-label:before{content:'●';margin-right:7px;color:var(--accent)}.map-label.warn:before{color:var(--warning-color,#ffa600)}.map-head>span:last-child{font-size:12px}
+#map-viewport{height:clamp(360px,65vh,680px);position:relative;overflow:auto;background:#10161e;cursor:grab}#map-viewport:active{cursor:grabbing}#map-canvas{width:100%;height:100%;min-height:100%}#map-image{width:100%;height:100%;object-fit:contain;display:block}#map-empty{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:24px;color:#c9d1d9}#map-empty ha-icon{--mdc-icon-size:48px;margin-bottom:16px}#map-empty p{font-size:14px;max-width:320px}
+.map-footer{padding:16px;min-height:88px}.map-footer h2{font-size:16px;font-weight:600;margin-bottom:6px}.map-footer>div>span{font-size:12px;color:var(--muted)}button{font:inherit;font-size:14px;cursor:pointer;border:0;border-radius:8px;background:var(--secondary-background-color,#eee);color:var(--ink);padding:11px 14px;display:inline-flex;gap:8px;align-items:center;justify-content:center;min-height:44px}button:hover:not(:disabled){filter:brightness(.92)}button:disabled{opacity:.42;cursor:not-allowed}button:focus-visible,summary:focus-visible{outline:3px solid var(--accent);outline-offset:3px}.zoom{display:flex;gap:4px}.zoom button{padding:8px 11px}.zoom button:nth-child(2){font-size:12px;min-width:54px}
+aside{padding:20px}.aside-top{font-size:14px;color:var(--muted)}aside>h2{font-size:28px;line-height:1.2;margin:20px 0 8px}.muted{font-size:13px;color:var(--muted)}.muted:empty,#command:empty,#error:empty{display:none}.metrics{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:26px}.metrics span,.session-metrics span{display:block;color:var(--muted);font-size:13px;margin-bottom:8px}.metrics strong{font-size:28px;font-weight:500}.progress-track{height:4px;border-radius:8px;background:var(--divider-color,#ddd);margin:20px 0 24px;overflow:hidden}.progress-track span{display:block;height:100%;background:var(--accent);transition:width .4s}.session-metrics{display:grid;gap:16px}.session-metrics>div{display:flex;align-items:center;justify-content:space-between;gap:12px}.session-metrics span{margin:0}.session-metrics b{font-size:14px;font-weight:500}.footnote{font-size:12px;color:var(--muted);line-height:1.6}.actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:24px}.actions button:last-child{grid-column:1/-1}.actions .primary{background:var(--accent);color:var(--text-primary-color,#fff)}.actions ha-icon{--mdc-icon-size:20px}#command{font-size:13px;color:var(--muted);margin-bottom:0}#error{font-size:13px;color:var(--error-color,#db4437)}
+.lower{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:8px}.panel{padding:20px}.section-heading{margin-bottom:16px}.section-heading h2{display:flex;align-items:center;gap:10px;font-size:20px}.section-heading ha-icon{--mdc-icon-size:22px}#planner-reason{font-size:16px}details{border-top:1px solid var(--line);margin-top:16px}summary{font-size:14px;cursor:pointer;padding:16px 0;color:var(--accent)}.history{margin-top:8px}.empty-history{padding:24px 0;color:var(--muted);font-size:14px}.table-scroll{overflow:auto}table{width:100%;text-align:left;border-collapse:collapse;font-size:14px;white-space:nowrap}th{font-size:13px;color:var(--muted);font-weight:500;padding:12px 20px 12px 0}td{padding:18px 20px 18px 0;border-top:1px solid var(--line)}td small{display:block;color:var(--muted);margin-top:6px;font-size:12px}
+:host([data-view="planning"]) main,:host([data-view="settings"]) main{max-width:850px}:host([data-view="planning"]) .lower,:host([data-view="settings"]) .lower{grid-template-columns:1fr;margin-top:0}:host([data-view="history"]) .history{margin-top:0}:host([data-view="planning"]) #planner-details,:host([data-view="settings"]) #settings-details{border:0;margin:0}:host([data-view="planning"]) #planner-details>summary,:host([data-view="settings"]) #settings-details>summary{display:none}hui-entities-card{--ha-card-border-width:0;--ha-card-box-shadow:none}
+@media(max-width:800px){.layout{grid-template-columns:1fr}.lower{grid-template-columns:1fr}#map-viewport{height:45vh;min-height:300px;max-height:480px}aside,.panel{padding:16px}aside>h2{font-size:25px}.map-head{flex-wrap:wrap}.badge{font-size:12px}.metrics{margin-top:20px}.map-footer{padding:12px 16px}.section-heading{flex-wrap:wrap}.tag{font-size:11px}}
 `;
 
 if (!customElements.get("eufy-mower-card")) customElements.define("eufy-mower-card", EufyMowerCard);

--- a/custom_components/eufy_robomow/image.py
+++ b/custom_components/eufy_robomow/image.py
@@ -53,13 +53,8 @@ async def async_setup_entry(
         return
 
     coordinator: EufyMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
-    cache_file = Path(
-        hass.config.path(
-            MAP_CACHE_DIRECTORY,
-            entry.entry_id,
-            "latest.mapbundle",
-        )
-    )
+    cache_root = Path(hass.config.path(MAP_CACHE_DIRECTORY))
+    cache_file = cache_root / entry.entry_id / "latest.mapbundle"
     async_add_entities(
         [
             EufyRobomowMapImage(
@@ -70,6 +65,7 @@ async def async_setup_entry(
                     settings=settings,
                     device_id=entry.data[CONF_DEVICE_ID],
                     cache_file=cache_file,
+                    cache_root=cache_root,
                 ),
                 entry,
             )

--- a/custom_components/eufy_robomow/image.py
+++ b/custom_components/eufy_robomow/image.py
@@ -1,0 +1,165 @@
+"""Optional read-only E15 map image."""
+
+from __future__ import annotations
+
+from functools import partial
+import logging
+from pathlib import Path
+
+from homeassistant.components.image import ImageEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    CONF_DEVICE_ID,
+    CONF_LOCAL_KEY,
+    CONF_MAP_CERTIFICATE_FINGERPRINT,
+    CONF_MAP_SOURCE_URL,
+    DOMAIN,
+    DP_TASK_ACTIVE,
+)
+from .coordinator import EufyMowerCoordinator
+from .map import MapSnapshot, merge_live_snapshots
+from .map_renderer import MAP_CONTENT_TYPE, render_map_svg
+from .map_source import (
+    MAP_CACHE_DIRECTORY,
+    MAP_STREAM_REFRESH_INTERVAL,
+    MapSource,
+    MapSourceError,
+    MapSourceSettings,
+)
+
+_LOGGER = logging.getLogger(__name__)
+SCAN_INTERVAL = MAP_STREAM_REFRESH_INTERVAL
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the map only when an optional source is configured."""
+    settings = MapSourceSettings.from_values(
+        base_url=entry.options.get(CONF_MAP_SOURCE_URL, ""),
+        certificate_fingerprint=entry.options.get(
+            CONF_MAP_CERTIFICATE_FINGERPRINT,
+            "",
+        ),
+        local_key=entry.data[CONF_LOCAL_KEY],
+    )
+    if settings is None:
+        return
+
+    coordinator: EufyMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    cache_file = Path(
+        hass.config.path(
+            MAP_CACHE_DIRECTORY,
+            entry.entry_id,
+            "latest.mapbundle",
+        )
+    )
+    async_add_entities(
+        [
+            EufyRobomowMapImage(
+                hass,
+                coordinator,
+                MapSource(
+                    hass,
+                    settings=settings,
+                    device_id=entry.data[CONF_DEVICE_ID],
+                    cache_file=cache_file,
+                ),
+                entry,
+            )
+        ],
+        update_before_add=True,
+    )
+
+
+class EufyRobomowMapImage(ImageEntity):
+    """Expose the latest validated E15 map as an SVG image."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "map"
+    _attr_icon = "mdi:map"
+    _attr_content_type = MAP_CONTENT_TYPE
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        coordinator: EufyMowerCoordinator,
+        source: MapSource,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(hass)
+        self._hass = hass
+        self._coordinator = coordinator
+        self._source = source
+        self._content: bytes | None = None
+        self._render_key: tuple[str, bool] | None = None
+        self._live_snapshot: MapSnapshot | None = None
+        self._attr_unique_id = f"{entry.data[CONF_DEVICE_ID]}_map"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.data[CONF_DEVICE_ID])},
+            name="Eufy Robomow E15",
+            manufacturer="Eufy (Anker)",
+            model="E15",
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return whether a valid current or cached map is available."""
+        return self._content is not None
+
+    def image(self) -> bytes | None:
+        """Return the current rendered map."""
+        return self._content
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Expose bounded, secret-safe acquisition health."""
+        status = self._source.status
+        return {
+            "acquisition_status": status.state,
+            "acquisition_last_success": status.last_success,
+            "acquisition_last_error": status.last_error,
+        }
+
+    async def async_update(self) -> None:
+        """Fetch and render the latest valid map."""
+        include_cleaned_paths = bool(self._coordinator.data.get(DP_TASK_ACTIVE, False))
+        try:
+            loaded = await self._source.async_refresh(
+                streaming=include_cleaned_paths,
+            )
+        except MapSourceError as exc:
+            _LOGGER.debug("E15 map is not available yet: %s", exc)
+            return
+
+        if include_cleaned_paths:
+            snapshot = (
+                merge_live_snapshots(self._live_snapshot, loaded.snapshot)
+                if self._live_snapshot is not None
+                else loaded.snapshot
+            )
+            self._live_snapshot = snapshot
+        else:
+            snapshot = loaded.snapshot
+            self._live_snapshot = None
+
+        render_key = (loaded.snapshot_id, include_cleaned_paths)
+        if render_key == self._render_key:
+            return
+
+        self._content = await self._hass.async_add_executor_job(
+            partial(
+                render_map_svg,
+                snapshot,
+                include_cleaned_paths=include_cleaned_paths,
+            )
+        )
+        self._render_key = render_key
+        self._attr_image_last_updated = loaded.captured_at
+        self.async_update_token()

--- a/custom_components/eufy_robomow/image.py
+++ b/custom_components/eufy_robomow/image.py
@@ -78,6 +78,8 @@ class EufyRobomowMapImage(ImageEntity):
     """Expose the latest validated E15 map as an SVG image."""
 
     _attr_has_entity_name = True
+    # ImageEntity defaults to no polling; our source needs the platform timer.
+    _attr_should_poll = True
     _attr_translation_key = "map"
     _attr_icon = "mdi:map"
     _attr_content_type = MAP_CONTENT_TYPE

--- a/custom_components/eufy_robomow/lawn_mower.py
+++ b/custom_components/eufy_robomow/lawn_mower.py
@@ -9,7 +9,6 @@ from homeassistant.components.lawn_mower import (
     LawnMowerEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -47,7 +46,7 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
     _attr_has_entity_name = True
     _attr_translation_key = "lawn_mower"
     _attr_icon = "mdi:robot-mower"
-    _attr_supported_features = (
+    _CONTROL_FEATURES = (
         LawnMowerEntityFeature.START_MOWING
         | LawnMowerEntityFeature.PAUSE
         | LawnMowerEntityFeature.DOCK
@@ -67,6 +66,13 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
             manufacturer="Eufy (Anker)",
             model="E15",
         )
+
+    @property
+    def supported_features(self) -> LawnMowerEntityFeature:
+        """Expose controls only after the user explicitly opts in."""
+        if not self.coordinator.control_enabled:
+            return LawnMowerEntityFeature(0)
+        return self._CONTROL_FEATURES
 
     # ── activity ──────────────────────────────────────────────────────────────
 

--- a/custom_components/eufy_robomow/lawn_mower.py
+++ b/custom_components/eufy_robomow/lawn_mower.py
@@ -1,4 +1,5 @@
 """Lawn mower entity for Eufy Robomow."""
+
 from __future__ import annotations
 
 import logging
@@ -17,16 +18,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     DOMAIN,
     CONF_DEVICE_ID,
-    DP_TASK_ACTIVE,
     DP_PAUSED,
     DP_PROGRESS,
-    CMD_START,
-    CMD_PAUSE,
-    CMD_RESUME,
-    CMD_DOCK,
     RETURNING_THRESHOLD,
 )
 from .coordinator import EufyMowerCoordinator
+from .telemetry import task_active
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,11 +74,13 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
     # ── activity ──────────────────────────────────────────────────────────────
 
     @property
-    def activity(self) -> LawnMowerActivity:
-        dps = self.coordinator.data
-        dp1   = dps.get(DP_TASK_ACTIVE, False)
-        dp2   = dps.get(DP_PAUSED,      False)
-        dp118 = dps.get(DP_PROGRESS,    0)
+    def activity(self) -> LawnMowerActivity | None:
+        dps = self.coordinator.local_dps
+        dp1 = task_active(dps)
+        if type(dp1) is not bool:
+            return None
+        dp2 = dps.get(DP_PAUSED, False)
+        dp118 = dps.get(DP_PROGRESS, 0)
 
         # Paused: task active but movement stopped
         if dp1 and dp2:
@@ -101,23 +100,20 @@ class EufyRobomowEntity(CoordinatorEntity[EufyMowerCoordinator], LawnMowerEntity
         # DP1 absent or False → no active session → docked / idle
         return LawnMowerActivity.DOCKED
 
-    # ── commands ──────────────────────────────────────────────────────────────
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {
+            "operating_mode": self.coordinator.operating_mode,
+            "telemetry_updated_at": self.coordinator.last_local_update,
+            "command": self.coordinator.command.as_dict() if self.coordinator.command else None,
+        }
 
     async def async_start_mowing(self) -> None:
-        """Start or resume mowing."""
-        current = self.activity
-        if current == LawnMowerActivity.PAUSED:
-            dp, val = CMD_RESUME
-        else:
-            dp, val = CMD_START
-        await self.coordinator.async_send_command(dp, val)
+        action = "resume" if self.activity == LawnMowerActivity.PAUSED else "start"
+        await self.coordinator.async_send_mower_command(action)
 
     async def async_pause(self) -> None:
-        """Pause the mowing session."""
-        dp, val = CMD_PAUSE
-        await self.coordinator.async_send_command(dp, val)
+        await self.coordinator.async_send_mower_command("pause")
 
     async def async_dock(self) -> None:
-        """Stop mowing and return to base."""
-        dp, val = CMD_DOCK
-        await self.coordinator.async_send_command(dp, val)
+        await self.coordinator.async_send_mower_command("dock")

--- a/custom_components/eufy_robomow/manifest.json
+++ b/custom_components/eufy_robomow/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "eufy_robomow",
   "name": "Eufy Robomow",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "config_flow": true,
   "documentation": "https://github.com/keesmod/eufy-robomow-ha",
   "issue_tracker": "https://github.com/keesmod/eufy-robomow-ha/issues",
-  "requirements": ["tinytuya==1.20.0"],
+  "requirements": ["requests==2.34.2", "tinytuya==1.20.0"],
   "dependencies": [],
   "codeowners": ["@keesmod"],
   "iot_class": "local_polling"

--- a/custom_components/eufy_robomow/manifest.json
+++ b/custom_components/eufy_robomow/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "eufy_robomow",
   "name": "Eufy Robomow",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "config_flow": true,
   "documentation": "https://github.com/keesmod/eufy-robomow-ha",
   "issue_tracker": "https://github.com/keesmod/eufy-robomow-ha/issues",

--- a/custom_components/eufy_robomow/manifest.json
+++ b/custom_components/eufy_robomow/manifest.json
@@ -3,10 +3,10 @@
   "name": "Eufy Robomow",
   "version": "0.4.0",
   "config_flow": true,
-  "documentation": "https://github.com/jnicolaes/eufy-robomow-ha",
-  "issue_tracker": "https://github.com/jnicolaes/eufy-robomow-ha/issues",
-  "requirements": ["tinytuya>=1.13.0", "requests>=2.31.0"],
+  "documentation": "https://github.com/keesmod/eufy-robomow-ha",
+  "issue_tracker": "https://github.com/keesmod/eufy-robomow-ha/issues",
+  "requirements": ["tinytuya==1.20.0"],
   "dependencies": [],
-  "codeowners": ["@jnicolaes"],
+  "codeowners": ["@keesmod"],
   "iot_class": "local_polling"
 }

--- a/custom_components/eufy_robomow/manifest.json
+++ b/custom_components/eufy_robomow/manifest.json
@@ -1,12 +1,20 @@
 {
   "domain": "eufy_robomow",
   "name": "Eufy Robomow",
-  "version": "0.5.1",
+  "codeowners": [
+    "@keesmod"
+  ],
   "config_flow": true,
+  "dependencies": [
+    "frontend",
+    "http"
+  ],
   "documentation": "https://github.com/keesmod/eufy-robomow-ha",
+  "iot_class": "local_polling",
   "issue_tracker": "https://github.com/keesmod/eufy-robomow-ha/issues",
-  "requirements": ["requests==2.34.2", "tinytuya==1.20.0"],
-  "dependencies": [],
-  "codeowners": ["@keesmod"],
-  "iot_class": "local_polling"
+  "requirements": [
+    "requests==2.34.2",
+    "tinytuya==1.20.0"
+  ],
+  "version": "0.7.0"
 }

--- a/custom_components/eufy_robomow/map.py
+++ b/custom_components/eufy_robomow/map.py
@@ -305,8 +305,9 @@ def _decode_position(
 ) -> Point | None:
     encoded_x = message.integer(x_field)
     encoded_y = message.integer(y_field)
-    if not allow_omitted_zero and encoded_x is None and encoded_y is None:
-        return None
+    if encoded_x is None and encoded_y is None:
+        if not allow_omitted_zero or message.fields:
+            return None
     return Point(
         x=_decode_sint32(encoded_x or 0),
         y=_decode_sint32(encoded_y or 0),

--- a/custom_components/eufy_robomow/map.py
+++ b/custom_components/eufy_robomow/map.py
@@ -1,0 +1,341 @@
+"""Strict decoding and normalization for Eufy E15 map snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+_MAX_VARINT_BYTES = 10
+
+
+class MapDecodeError(ValueError):
+    """Raised when an E15 map payload is malformed or unsupported."""
+
+
+@dataclass(frozen=True, slots=True)
+class Point:
+    """One point in the mower's local map coordinate system."""
+
+    x: int
+    y: int
+
+
+@dataclass(frozen=True, slots=True)
+class MapSnapshot:
+    """Confirmed read-only E15 geometry from one coherent map snapshot."""
+
+    map_id: int
+    boundary: tuple[Point, ...]
+    base_areas: tuple[tuple[Point, ...], ...]
+    no_go_areas: tuple[tuple[Point, ...], ...]
+    pathways: tuple[tuple[Point, ...], ...]
+    cleaned_paths: tuple[tuple[Point, ...], ...]
+    mower_position: Point | None
+    tracking_position: Point | None = None
+
+
+ProtoValue = int | bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _ProtoMessage:
+    fields: dict[int, tuple[ProtoValue, ...]]
+
+    def integer(self, field_number: int, *, default: int | None = None) -> int | None:
+        values = tuple(
+            value
+            for value in self.fields.get(field_number, ())
+            if isinstance(value, int)
+        )
+        return values[-1] if values else default
+
+    def byte_strings(self, field_number: int) -> tuple[bytes, ...]:
+        return tuple(
+            value
+            for value in self.fields.get(field_number, ())
+            if isinstance(value, bytes)
+        )
+
+    def messages(self, field_number: int) -> tuple[_ProtoMessage, ...]:
+        return tuple(
+            _decode_message(value) for value in self.byte_strings(field_number)
+        )
+
+
+def parse_map_snapshot(
+    map_payload: bytes,
+    clean_path_payload: bytes,
+    navigation_path_payload: bytes,
+) -> MapSnapshot:
+    """Decode the three E15 P2P stream files into one typed snapshot."""
+    try:
+        map_root = _decode_message(map_payload)
+        map_envelope = _only_message(map_root, 2, "map envelope")
+        map_record = _only_message(map_envelope, 1, "map record")
+        clean_path = _decode_message(clean_path_payload)
+        navigation_path = _decode_message(navigation_path_payload)
+
+        map_id = _required_integer(map_record, 16, "map identifier")
+        boundary = _decode_boundary(map_record)
+        cleaned_paths, tracking_position = _decode_cleaned_paths(clean_path)
+
+        mower_messages = map_record.messages(8)
+        mower_position = (
+            _decode_position(
+                mower_messages[-1],
+                x_field=2,
+                y_field=3,
+                allow_omitted_zero=True,
+            )
+            if mower_messages
+            else None
+        )
+        if mower_position is None:
+            mower_position = _decode_position(
+                navigation_path,
+                x_field=2,
+                y_field=3,
+            )
+
+        base_areas = tuple(
+            polygon
+            for area in map_record.messages(26)
+            for polygon in (_decode_nested_polygon(area, polygon_field=2),)
+            if polygon
+        )
+        no_go_areas = tuple(
+            polygon
+            for restriction in map_record.messages(11)
+            for polygon in (_decode_repeated_points(restriction, field_number=1),)
+            if polygon
+        )
+        pathways = tuple(
+            path
+            for pathway in map_record.messages(18)
+            for path in (_decode_repeated_points(pathway, field_number=1),)
+            if path
+        )
+    except MapDecodeError:
+        raise
+    except (OverflowError, ValueError) as exc:
+        raise MapDecodeError(f"Malformed E15 map payload: {exc}") from exc
+
+    return MapSnapshot(
+        map_id=map_id,
+        boundary=boundary,
+        base_areas=base_areas,
+        no_go_areas=no_go_areas,
+        pathways=pathways,
+        cleaned_paths=cleaned_paths,
+        mower_position=mower_position,
+        tracking_position=tracking_position,
+    )
+
+
+def merge_live_snapshots(
+    previous: MapSnapshot,
+    current: MapSnapshot,
+) -> MapSnapshot:
+    """Accumulate deduplicated mowing coverage from consecutive live deltas."""
+    if previous.map_id != current.map_id:
+        return current
+
+    cleaned_paths = _unique_coverage_segments(
+        previous.cleaned_paths,
+        current.cleaned_paths,
+    )
+    return replace(
+        current,
+        cleaned_paths=cleaned_paths,
+        tracking_position=current.tracking_position or previous.tracking_position,
+    )
+
+
+def _decode_message(payload: bytes) -> _ProtoMessage:
+    fields: dict[int, list[ProtoValue]] = {}
+    position = 0
+
+    while position < len(payload):
+        tag, position = _read_varint(payload, position)
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+        if field_number == 0:
+            raise MapDecodeError("Protobuf field number 0 is invalid")
+
+        value: ProtoValue
+        if wire_type == 0:
+            value, position = _read_varint(payload, position)
+        elif wire_type == 2:
+            length, position = _read_varint(payload, position)
+            end = position + length
+            if end > len(payload):
+                raise MapDecodeError("Length-delimited protobuf field exceeds payload")
+            value = payload[position:end]
+            position = end
+        else:
+            raise MapDecodeError(f"Unsupported protobuf wire type {wire_type}")
+
+        fields.setdefault(field_number, []).append(value)
+
+    return _ProtoMessage(
+        fields={field_number: tuple(values) for field_number, values in fields.items()}
+    )
+
+
+def _read_varint(payload: bytes, position: int) -> tuple[int, int]:
+    value = 0
+    for byte_index in range(_MAX_VARINT_BYTES):
+        if position >= len(payload):
+            raise MapDecodeError("Truncated protobuf varint")
+        current = payload[position]
+        position += 1
+        value |= (current & 0x7F) << (7 * byte_index)
+        if current & 0x80 == 0:
+            return value, position
+    raise MapDecodeError("Protobuf varint exceeds 10 bytes")
+
+
+def _decode_boundary(map_record: _ProtoMessage) -> tuple[Point, ...]:
+    boundary_containers = map_record.messages(10)
+    if not boundary_containers:
+        raise MapDecodeError("E15 map has no boundary container")
+
+    boundary_layers = boundary_containers[-1].messages(3)
+    if not boundary_layers:
+        raise MapDecodeError("E15 map has no active boundary")
+
+    boundary = _decode_repeated_points(boundary_layers[-1], field_number=1)
+    if len(boundary) < 3:
+        raise MapDecodeError("E15 map boundary has fewer than three points")
+    return boundary
+
+
+def _decode_cleaned_paths(
+    clean_path: _ProtoMessage,
+) -> tuple[tuple[tuple[Point, ...], ...], Point | None]:
+    """Separate mowing coverage from transport and pose events."""
+    segments: list[tuple[Point, ...]] = []
+    current: list[Point] = []
+    tracking_position: Point | None = None
+
+    for path_item in clean_path.messages(7):
+        point_messages = path_item.messages(1)
+        if not point_messages:
+            continue
+        point = _decode_position(point_messages[-1], allow_omitted_zero=True)
+        if point is None:
+            continue
+
+        tracking_position = point
+        path_event = path_item.integer(2, default=0) or 0
+        if path_event != 0:
+            if current:
+                segments.append(tuple(current))
+                current = []
+            continue
+
+        current.append(point)
+
+    if current:
+        segments.append(tuple(current))
+    return tuple(segments), tracking_position
+
+
+def _unique_coverage_segments(
+    *path_groups: tuple[tuple[Point, ...], ...],
+) -> tuple[tuple[Point, ...], ...]:
+    """Return stable continuous paths without duplicate coverage."""
+    merged: list[list[Point]] = []
+    seen: set[tuple[tuple[int, int], tuple[int, int]]] = set()
+
+    for paths in path_groups:
+        for path in paths:
+            for start, end in zip(path, path[1:], strict=False):
+                if start == end:
+                    continue
+                start_key = (start.x, start.y)
+                end_key = (end.x, end.y)
+                key = (
+                    (start_key, end_key)
+                    if start_key <= end_key
+                    else (end_key, start_key)
+                )
+                if key in seen:
+                    continue
+                seen.add(key)
+                if merged and merged[-1][-1] == start:
+                    merged[-1].append(end)
+                else:
+                    merged.append([start, end])
+
+    return tuple(tuple(path) for path in merged)
+
+
+def _decode_nested_polygon(
+    message: _ProtoMessage,
+    *,
+    polygon_field: int,
+) -> tuple[Point, ...]:
+    polygon_messages = message.messages(polygon_field)
+    if not polygon_messages:
+        return ()
+    return _decode_repeated_points(polygon_messages[-1], field_number=1)
+
+
+def _decode_repeated_points(
+    message: _ProtoMessage,
+    *,
+    field_number: int,
+) -> tuple[Point, ...]:
+    return tuple(
+        point
+        for point in (
+            _decode_position(candidate, allow_omitted_zero=True)
+            for candidate in message.messages(field_number)
+        )
+        if point is not None
+    )
+
+
+def _decode_position(
+    message: _ProtoMessage,
+    *,
+    x_field: int = 1,
+    y_field: int = 2,
+    allow_omitted_zero: bool = False,
+) -> Point | None:
+    encoded_x = message.integer(x_field)
+    encoded_y = message.integer(y_field)
+    if not allow_omitted_zero and encoded_x is None and encoded_y is None:
+        return None
+    return Point(
+        x=_decode_sint32(encoded_x or 0),
+        y=_decode_sint32(encoded_y or 0),
+    )
+
+
+def _decode_sint32(value: int) -> int:
+    if value < 0 or value > 0xFFFFFFFF:
+        raise MapDecodeError("E15 coordinate is outside sint32 range")
+    return (value >> 1) ^ -(value & 1)
+
+
+def _only_message(
+    message: _ProtoMessage,
+    field_number: int,
+    label: str,
+) -> _ProtoMessage:
+    values = message.messages(field_number)
+    if len(values) != 1:
+        raise MapDecodeError(f"E15 {label} must occur exactly once")
+    return values[0]
+
+
+def _required_integer(
+    message: _ProtoMessage,
+    field_number: int,
+    label: str,
+) -> int:
+    value = message.integer(field_number)
+    if value is None:
+        raise MapDecodeError(f"E15 map has no {label}")
+    return value

--- a/custom_components/eufy_robomow/map_renderer.py
+++ b/custom_components/eufy_robomow/map_renderer.py
@@ -1,0 +1,257 @@
+"""Deterministic, script-free SVG rendering for Eufy E15 maps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .map import MapSnapshot, Point
+
+MAP_CONTENT_TYPE = "image/svg+xml"
+_WIDTH = 720
+_HEIGHT = 900
+_MARGIN = 48
+
+# The mower coordinates describe the navigation anchor, not the icon centre.
+_MOWER_ICON_OFFSET_X = 20
+_MOWER_ICON_OFFSET_Y = 68
+
+
+@dataclass(frozen=True, slots=True)
+class _Projection:
+    minimum_x: int
+    minimum_y: int
+    scale: float
+    offset_x: float
+    offset_y: float
+
+    def point(self, value: Point) -> tuple[float, float]:
+        return (
+            self.offset_x + ((value.x - self.minimum_x) * self.scale),
+            self.offset_y + ((value.y - self.minimum_y) * self.scale),
+        )
+
+
+def render_map_svg(
+    snapshot: MapSnapshot,
+    *,
+    include_cleaned_paths: bool = False,
+) -> bytes:
+    """Render a normalized map snapshot as an iOS-like SVG."""
+    pathways = tuple(
+        pathway
+        for pathway in snapshot.pathways
+        if any(not _point_in_polygon(point, snapshot.boundary) for point in pathway)
+    )
+    cleaned_paths = snapshot.cleaned_paths if include_cleaned_paths else ()
+    mower_position = _rendered_mower_position(
+        snapshot,
+        cleaned_paths=cleaned_paths,
+        include_cleaned_paths=include_cleaned_paths,
+    )
+    station_position = snapshot.mower_position if include_cleaned_paths else None
+    projection = _projection(
+        _visible_points(
+            snapshot,
+            pathways=pathways,
+            cleaned_paths=cleaned_paths,
+            mower_position=mower_position,
+            station_position=station_position,
+        )
+    )
+    rendered_boundary = _render_points(snapshot.boundary, projection)
+    definitions = [
+        '<clipPath id="mowing-boundary-clip">'
+        f'<polygon points="{rendered_boundary}" />'
+        "</clipPath>"
+    ]
+    elements = [f'<polygon class="boundary" points="{rendered_boundary}" />']
+
+    rendered_cleaned_paths = "\n      ".join(
+        f'<polyline class="cleaned-path" points="{_render_points(path, projection)}" />'
+        for path in cleaned_paths
+    )
+    if rendered_cleaned_paths:
+        elements.append(
+            '<g class="cleaned-area" clip-path="url(#mowing-boundary-clip)">'
+            f"\n      {rendered_cleaned_paths}\n    </g>"
+        )
+
+    elements.extend(
+        f'<polygon class="base-area" points="{_render_points(area, projection)}" />'
+        for area in snapshot.base_areas
+    )
+    elements.extend(
+        f'<polygon class="no-go-area" points="{_render_points(area, projection)}" />'
+        for area in snapshot.no_go_areas
+    )
+    for pathway in pathways:
+        rendered = _render_points(pathway, projection)
+        elements.append(f'<polyline class="pathway" points="{rendered}" />')
+        elements.append(f'<polyline class="pathway-center" points="{rendered}" />')
+
+    if station_position is not None:
+        station_x, station_y = projection.point(station_position)
+        elements.append(
+            _render_charging_station(
+                station_x + _MOWER_ICON_OFFSET_X,
+                station_y + _MOWER_ICON_OFFSET_Y,
+            )
+        )
+
+    if mower_position is not None:
+        mower_x, mower_y = projection.point(mower_position)
+        if not include_cleaned_paths:
+            mower_x += _MOWER_ICON_OFFSET_X
+            mower_y += _MOWER_ICON_OFFSET_Y
+        elements.append(
+            _render_mower(
+                mower_x,
+                mower_y,
+                is_live=include_cleaned_paths,
+            )
+        )
+
+    defs = "\n    ".join(definitions)
+    body = "\n    ".join(elements)
+    svg = f"""<svg xmlns="http://www.w3.org/2000/svg" width="{_WIDTH}" height="{_HEIGHT}" viewBox="0 0 {_WIDTH} {_HEIGHT}">
+  <title>Eufy mower map {snapshot.map_id}</title>
+  <defs>
+    {defs}
+  </defs>
+  <rect class="background" width="{_WIDTH}" height="{_HEIGHT}" />
+  <style>
+    .background {{ fill: #020505; }}
+    .boundary {{ fill: #153f16; stroke: #49a6ff; stroke-width: 5; stroke-linejoin: round; }}
+    .base-area {{ fill: #347f91; fill-opacity: .9; stroke: #55aaff; stroke-width: 4; stroke-dasharray: 12 8; stroke-linejoin: round; }}
+    .no-go-area {{ fill: #050607; stroke: #626a74; stroke-width: 2; stroke-linejoin: round; }}
+    .pathway {{ fill: none; stroke: #ffbd00; stroke-width: 10; stroke-linecap: round; stroke-linejoin: round; }}
+    .pathway-center {{ fill: none; stroke: #fff7cf; stroke-width: 1.5; stroke-dasharray: 8 8; stroke-linecap: round; }}
+    .cleaned-area {{ opacity: .58; }}
+    .cleaned-path {{ fill: none; stroke: #82967e; stroke-width: 54; stroke-linecap: round; stroke-linejoin: round; }}
+    .mower-shadow {{ fill: #000; opacity: .6; }}
+    .mower-wheel {{ fill: #25292d; stroke: #747b80; stroke-width: 1; }}
+    .mower-body {{ fill: #8e9498; stroke: #eceff1; stroke-width: 1.5; }}
+    .mower-panel {{ fill: #d1d4d6; stroke: #61676b; stroke-width: 1; }}
+    .mower-accent {{ fill: #e34c56; }}
+    .mower-lightning {{ fill: #39f27d; }}
+    .station-shadow {{ fill: #000; opacity: .55; }}
+    .station-body {{ fill: #353a3f; stroke: #5c646a; stroke-width: 1.5; }}
+    .station-top {{ fill: #484f55; }}
+    .station-lightning {{ fill: #f4f7f8; }}
+  </style>
+  <g>
+    {body}
+  </g>
+</svg>
+"""
+    return svg.encode()
+
+
+def _render_points(
+    points: tuple[Point, ...],
+    projection: _Projection,
+) -> str:
+    return " ".join(f"{x:.2f},{y:.2f}" for x, y in map(projection.point, points))
+
+
+def _render_mower(x: float, y: float, *, is_live: bool) -> str:
+    scale = " scale(.75)" if is_live else ""
+    lightning = (
+        ""
+        if is_live
+        else '<path class="mower-lightning" d="M 2 7 L -5 16 L 0 16 L -3 23 L 7 12 L 2 12 Z" />'
+    )
+    return f"""<g class="mower-marker" transform="translate({x:.2f} {y:.2f}){scale}">
+      <ellipse class="mower-shadow" cx="0" cy="3" rx="17" ry="25" />
+      <rect class="mower-wheel" x="-17" y="-14" width="5" height="29" rx="2" />
+      <rect class="mower-wheel" x="12" y="-14" width="5" height="29" rx="2" />
+      <path class="mower-body" d="M -11 -20 Q 0 -25 11 -20 L 13 15 Q 0 23 -13 15 Z" />
+      <rect class="mower-panel" x="-7" y="-14" width="14" height="22" rx="4" />
+      <rect class="mower-accent" x="-2" y="-19" width="4" height="8" rx="2" />
+      {lightning}
+    </g>"""
+
+
+def _render_charging_station(x: float, y: float) -> str:
+    return f"""<g class="charging-station" transform="translate({x:.2f} {y:.2f})">
+      <ellipse class="station-shadow" cx="0" cy="4" rx="15" ry="24" />
+      <path class="station-body" d="M -11 -19 Q 0 -22 11 -19 L 10 19 Q 0 23 -10 19 Z" />
+      <path class="station-top" d="M -8 -15 Q 0 -18 8 -15 L 7 -8 Q 0 -11 -7 -8 Z" />
+      <path class="station-lightning" d="M 2 -3 L -5 7 L 0 7 L -3 15 L 7 4 L 2 4 Z" />
+    </g>"""
+
+
+def _rendered_mower_position(
+    snapshot: MapSnapshot,
+    *,
+    cleaned_paths: tuple[tuple[Point, ...], ...],
+    include_cleaned_paths: bool,
+) -> Point | None:
+    if include_cleaned_paths:
+        if snapshot.tracking_position is not None:
+            return snapshot.tracking_position
+        for path in reversed(cleaned_paths):
+            if path:
+                return path[-1]
+        return None
+    return snapshot.mower_position
+
+
+def _point_in_polygon(point: Point, polygon: tuple[Point, ...]) -> bool:
+    inside = False
+    previous = polygon[-1]
+    for current in polygon:
+        crosses_y = (current.y > point.y) != (previous.y > point.y)
+        if crosses_y:
+            crossing_x = (
+                ((previous.x - current.x) * (point.y - current.y))
+                / (previous.y - current.y)
+            ) + current.x
+            if point.x < crossing_x:
+                inside = not inside
+        previous = current
+    return inside
+
+
+def _visible_points(
+    snapshot: MapSnapshot,
+    *,
+    pathways: tuple[tuple[Point, ...], ...],
+    cleaned_paths: tuple[tuple[Point, ...], ...],
+    mower_position: Point | None,
+    station_position: Point | None,
+) -> tuple[Point, ...]:
+    geometry = (
+        snapshot.boundary,
+        *snapshot.base_areas,
+        *snapshot.no_go_areas,
+        *pathways,
+        *cleaned_paths,
+    )
+    points = tuple(point for item in geometry for point in item)
+    if mower_position is not None:
+        points += (mower_position,)
+    if station_position is not None:
+        points += (station_position,)
+    return points
+
+
+def _projection(points: tuple[Point, ...]) -> _Projection:
+    minimum_x = min(point.x for point in points)
+    maximum_x = max(point.x for point in points)
+    minimum_y = min(point.y for point in points)
+    maximum_y = max(point.y for point in points)
+    width = max(maximum_x - minimum_x, 1)
+    height = max(maximum_y - minimum_y, 1)
+    available_width = _WIDTH - (2 * _MARGIN)
+    available_height = _HEIGHT - (2 * _MARGIN)
+    scale = min(available_width / width, available_height / height)
+    rendered_width = width * scale
+    rendered_height = height * scale
+    return _Projection(
+        minimum_x=minimum_x,
+        minimum_y=minimum_y,
+        scale=scale,
+        offset_x=_MARGIN + ((available_width - rendered_width) / 2),
+        offset_y=_MARGIN + ((available_height - rendered_height) / 2),
+    )

--- a/custom_components/eufy_robomow/map_renderer.py
+++ b/custom_components/eufy_robomow/map_renderer.py
@@ -11,9 +11,13 @@ _WIDTH = 720
 _HEIGHT = 900
 _MARGIN = 48
 
-# The mower coordinates describe the navigation anchor, not the icon centre.
-_MOWER_ICON_OFFSET_X = 20
-_MOWER_ICON_OFFSET_Y = 68
+# The observed mower fields locate a navigation anchor, while these fixed-size
+# SVG icons need a visual pixel offset. This affects presentation only; marker
+# centres are clamped so the offset cannot push an icon outside the canvas.
+_MARKER_VISUAL_OFFSET_X = 20
+_MARKER_VISUAL_OFFSET_Y = 68
+_MARKER_HALF_WIDTH = 20
+_MARKER_HALF_HEIGHT = 28
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,11 +41,7 @@ def render_map_svg(
     include_cleaned_paths: bool = False,
 ) -> bytes:
     """Render a normalized map snapshot as an iOS-like SVG."""
-    pathways = tuple(
-        pathway
-        for pathway in snapshot.pathways
-        if any(not _point_in_polygon(point, snapshot.boundary) for point in pathway)
-    )
+    pathways = snapshot.pathways
     cleaned_paths = snapshot.cleaned_paths if include_cleaned_paths else ()
     mower_position = _rendered_mower_position(
         snapshot,
@@ -90,19 +90,24 @@ def render_map_svg(
         elements.append(f'<polyline class="pathway-center" points="{rendered}" />')
 
     if station_position is not None:
-        station_x, station_y = projection.point(station_position)
+        station_x, station_y = _marker_position(
+            station_position,
+            projection,
+            apply_visual_offset=True,
+        )
         elements.append(
             _render_charging_station(
-                station_x + _MOWER_ICON_OFFSET_X,
-                station_y + _MOWER_ICON_OFFSET_Y,
+                station_x,
+                station_y,
             )
         )
 
     if mower_position is not None:
-        mower_x, mower_y = projection.point(mower_position)
-        if not include_cleaned_paths:
-            mower_x += _MOWER_ICON_OFFSET_X
-            mower_y += _MOWER_ICON_OFFSET_Y
+        mower_x, mower_y = _marker_position(
+            mower_position,
+            projection,
+            apply_visual_offset=not include_cleaned_paths,
+        )
         elements.append(
             _render_mower(
                 mower_x,
@@ -154,6 +159,22 @@ def _render_points(
     return " ".join(f"{x:.2f},{y:.2f}" for x, y in map(projection.point, points))
 
 
+def _marker_position(
+    position: Point,
+    projection: _Projection,
+    *,
+    apply_visual_offset: bool,
+) -> tuple[float, float]:
+    x, y = projection.point(position)
+    if apply_visual_offset:
+        x += _MARKER_VISUAL_OFFSET_X
+        y += _MARKER_VISUAL_OFFSET_Y
+    return (
+        min(max(x, _MARKER_HALF_WIDTH), _WIDTH - _MARKER_HALF_WIDTH),
+        min(max(y, _MARKER_HALF_HEIGHT), _HEIGHT - _MARKER_HALF_HEIGHT),
+    )
+
+
 def _render_mower(x: float, y: float, *, is_live: bool) -> str:
     scale = " scale(.75)" if is_live else ""
     lightning = (
@@ -195,22 +216,6 @@ def _rendered_mower_position(
                 return path[-1]
         return None
     return snapshot.mower_position
-
-
-def _point_in_polygon(point: Point, polygon: tuple[Point, ...]) -> bool:
-    inside = False
-    previous = polygon[-1]
-    for current in polygon:
-        crosses_y = (current.y > point.y) != (previous.y > point.y)
-        if crosses_y:
-            crossing_x = (
-                ((previous.x - current.x) * (point.y - current.y))
-                / (previous.y - current.y)
-            ) + current.x
-            if point.x < crossing_x:
-                inside = not inside
-        previous = current
-    return inside
 
 
 def _visible_points(

--- a/custom_components/eufy_robomow/map_source.py
+++ b/custom_components/eufy_robomow/map_source.py
@@ -139,6 +139,12 @@ class MapSourceStatus:
     last_error: str | None
 
 
+@dataclass(frozen=True, slots=True)
+class _MapFetch:
+    encoded: bytes | None
+    etag: str | None = None
+
+
 class MapSource:
     """Fetch a map bundle and retain the latest valid snapshot."""
 
@@ -149,17 +155,19 @@ class MapSource:
         settings: MapSourceSettings,
         device_id: str,
         cache_file: Path,
+        cache_root: Path | None = None,
     ) -> None:
         self._hass = hass
         self._settings = settings
         self._device_id = device_id
         self._cache_file = cache_file
+        self._cache_root = cache_root or cache_file.parent
         self._current: LoadedMap | None = None
         self._last_error: str | None = None
         self._last_attempt: float | None = None
         self._consecutive_failures = 0
         self._streaming = False
-        self._etag: str | None = None
+        self._etags: dict[bool, str] = {}
 
     @property
     def status(self) -> MapSourceStatus:
@@ -185,15 +193,19 @@ class MapSource:
         self._streaming = streaming
         if (
             not mode_changed
-            and self._current is not None
             and self._last_attempt is not None
             and now - self._last_attempt < self._next_refresh_delay(streaming)
         ):
-            return self._current
+            if self._current is not None:
+                return self._current
+            raise MapSourceError(
+                self._last_error or "Map source refresh is waiting to retry"
+            )
         self._last_attempt = now
 
         try:
-            encoded = await self._async_fetch(streaming=streaming)
+            fetched = await self._async_fetch(streaming=streaming)
+            encoded = fetched.encoded
             if encoded is None:
                 if self._current is None:
                     raise MapSourceError("Map source returned no initial snapshot")
@@ -206,13 +218,17 @@ class MapSource:
                 self._device_id,
             )
             _reject_future_snapshot(loaded)
+            _reject_older_snapshot(loaded, self._current)
             if self._current is None or loaded.snapshot_id != self._current.snapshot_id:
                 await self._hass.async_add_executor_job(
                     write_cached_bundle,
                     self._cache_file,
                     encoded,
+                    self._cache_root,
                 )
             self._current = loaded
+            if fetched.etag is not None:
+                self._etags[streaming] = fetched.etag
             self._last_error = None
             self._consecutive_failures = 0
             return loaded
@@ -254,7 +270,7 @@ class MapSource:
             return interval
         return max(interval, min(2**self._consecutive_failures, 60))
 
-    async def _async_fetch(self, *, streaming: bool) -> bytes | None:
+    async def _async_fetch(self, *, streaming: bool) -> _MapFetch:
         session = async_get_clientsession(self._hass)
         ssl: bool | aiohttp.Fingerprint = True
         if self._settings.certificate_fingerprint is not None:
@@ -265,8 +281,8 @@ class MapSource:
             "Accept": MAP_BUNDLE_CONTENT_TYPE,
             MAP_MODE_HEADER: MAP_MODE_STREAM if streaming else MAP_MODE_IDLE,
         }
-        if self._etag is not None:
-            headers["If-None-Match"] = self._etag
+        if etag := self._etags.get(streaming):
+            headers["If-None-Match"] = etag
         async with session.get(
             f"{self._settings.base_url}/v1/map",
             headers=headers,
@@ -274,7 +290,7 @@ class MapSource:
             timeout=_REQUEST_TIMEOUT,
         ) as response:
             if response.status == 304:
-                return None
+                return _MapFetch(None)
             if response.status == 401:
                 raise MapSourceError("Map source rejected authentication")
             if response.status == 503:
@@ -298,9 +314,15 @@ class MapSource:
             if len(encoded) > _MAX_BUNDLE_SIZE:
                 raise MapSourceError("Map source response exceeds 16 MiB")
             etag = response.headers.get("ETag")
-            if etag and len(etag) <= 256 and "\n" not in etag and "\r" not in etag:
-                self._etag = etag
-            return encoded
+            valid_etag = (
+                etag
+                if etag
+                and len(etag) <= 256
+                and "\n" not in etag
+                and "\r" not in etag
+                else None
+            )
+            return _MapFetch(encoded, valid_etag)
 
 
 def decode_map_bundle(data: bytes, expected_device_id: str) -> LoadedMap:
@@ -387,10 +409,25 @@ def read_cached_bundle(path: Path) -> bytes:
     return path.read_bytes()
 
 
-def write_cached_bundle(path: Path, data: bytes) -> None:
+def write_cached_bundle(
+    path: Path,
+    data: bytes,
+    cache_root: Path | None = None,
+) -> None:
     """Atomically replace the single latest-good bundle."""
+    private_root = cache_root or path.parent
+    if private_root != path.parent and private_root not in path.parents:
+        raise MapSourceError("Map cache file is outside its private root")
+
+    private_root.mkdir(mode=0o700, parents=True, exist_ok=True)
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    os.chmod(path.parent, 0o700)
+    directory = path.parent
+    while True:
+        os.chmod(directory, 0o700)
+        if directory == private_root:
+            break
+        directory = directory.parent
+
     temporary = path.with_name(f".{path.name}-{uuid.uuid4().hex}")
     try:
         with temporary.open("xb") as stream:
@@ -458,3 +495,11 @@ def _safe_error_message(exc: BaseException) -> str:
 def _reject_future_snapshot(loaded: LoadedMap) -> None:
     if loaded.captured_at > datetime.now(tz=UTC) + timedelta(minutes=5):
         raise MapSourceError("Map source returned a future-dated snapshot")
+
+
+def _reject_older_snapshot(
+    loaded: LoadedMap,
+    current: LoadedMap | None,
+) -> None:
+    if current is not None and loaded.captured_at < current.captured_at:
+        raise MapSourceError("Map source returned an older snapshot")

--- a/custom_components/eufy_robomow/map_source.py
+++ b/custom_components/eufy_robomow/map_source.py
@@ -1,0 +1,460 @@
+"""Validated HTTPS source and latest-good cache for Eufy E15 maps."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+import hashlib
+import hmac
+from io import BytesIO
+import json
+import os
+from pathlib import Path
+import re
+import time
+import uuid
+from urllib.parse import urlsplit
+from zipfile import ZIP_STORED, BadZipFile, ZipFile, ZipInfo
+
+import aiohttp
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .map import MapDecodeError, MapSnapshot, parse_map_snapshot
+
+MAP_BUNDLE_CONTENT_TYPE = "application/vnd.eufy-robomow-map+zip"
+MAP_CACHE_DIRECTORY = "eufy_robomow_maps"
+MAP_REFRESH_INTERVAL = timedelta(minutes=5)
+MAP_STREAM_REFRESH_INTERVAL = timedelta(seconds=2)
+MAP_MODE_HEADER = "X-Eufy-Map-Mode"
+MAP_MODE_IDLE = "idle"
+MAP_MODE_STREAM = "stream"
+
+_MAP_FILENAME = "map.bin.stream"
+_CLEAN_PATH_FILENAME = "cleanPath.bin.stream"
+_NAV_PATH_FILENAME = "navPath.bin.stream"
+_MAP_FILENAMES = (
+    _MAP_FILENAME,
+    _CLEAN_PATH_FILENAME,
+    _NAV_PATH_FILENAME,
+)
+_MANIFEST_FILENAME = "manifest.json"
+_EXPECTED_MEMBERS = frozenset((*_MAP_FILENAMES, _MANIFEST_FILENAME))
+_MAX_MAP_FILE_SIZE = 5 * 1024 * 1024
+_MAX_BUNDLE_SIZE = 16 * 1024 * 1024
+_SCHEMA_VERSION = 1
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_TOKEN_CONTEXT = b"eufy-robomow-map-helper-v1"
+_REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30, connect=5)
+
+
+class MapSourceError(ValueError):
+    """Raised when a map source or bundle cannot be consumed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class MapSourceSettings:
+    """Validated optional map-source connection settings."""
+
+    base_url: str
+    access_token: str
+    certificate_fingerprint: bytes | None
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        base_url: str,
+        certificate_fingerprint: str,
+        local_key: str,
+    ) -> MapSourceSettings | None:
+        """Validate options, returning ``None`` when map support is disabled."""
+        normalized_url = base_url.strip().rstrip("/")
+        normalized_fingerprint = (
+            certificate_fingerprint.lower().replace(":", "").replace(" ", "")
+        )
+        if not normalized_url:
+            if normalized_fingerprint:
+                raise MapSourceError(
+                    "Map certificate fingerprint requires a map source URL"
+                )
+            return None
+
+        parsed = urlsplit(normalized_url)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise MapSourceError(
+                "Map source must be an HTTPS base URL without credentials, "
+                "query, or fragment"
+            )
+        if normalized_fingerprint and not _SHA256_PATTERN.fullmatch(
+            normalized_fingerprint
+        ):
+            raise MapSourceError(
+                "Map certificate fingerprint must be 64 hexadecimal characters"
+            )
+
+        encoded_key = local_key.encode()
+        if len(encoded_key) not in (16, 32):
+            raise MapSourceError("Mower local key must encode to 16 or 32 bytes")
+        access_token = hmac.new(
+            encoded_key,
+            _TOKEN_CONTEXT,
+            hashlib.sha256,
+        ).hexdigest()
+        return cls(
+            base_url=normalized_url,
+            access_token=access_token,
+            certificate_fingerprint=(
+                bytes.fromhex(normalized_fingerprint)
+                if normalized_fingerprint
+                else None
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedMap:
+    """One complete, validated E15 map snapshot."""
+
+    snapshot_id: str
+    captured_at: datetime
+    snapshot: MapSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class MapSourceStatus:
+    """Secret-safe operational status for the image entity."""
+
+    state: str
+    last_success: datetime | None
+    last_error: str | None
+
+
+class MapSource:
+    """Fetch a map bundle and retain the latest valid snapshot."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        settings: MapSourceSettings,
+        device_id: str,
+        cache_file: Path,
+    ) -> None:
+        self._hass = hass
+        self._settings = settings
+        self._device_id = device_id
+        self._cache_file = cache_file
+        self._current: LoadedMap | None = None
+        self._last_error: str | None = None
+        self._last_attempt: float | None = None
+        self._consecutive_failures = 0
+        self._streaming = False
+        self._etag: str | None = None
+
+    @property
+    def status(self) -> MapSourceStatus:
+        """Return acquisition health without exposing connection details."""
+        if self._current is None:
+            state = "error" if self._last_error else "starting"
+        elif self._last_error:
+            state = "stale"
+        else:
+            state = "healthy"
+        return MapSourceStatus(
+            state=state,
+            last_success=(
+                self._current.captured_at if self._current is not None else None
+            ),
+            last_error=self._last_error,
+        )
+
+    async def async_refresh(self, *, streaming: bool = False) -> LoadedMap:
+        """Fetch the latest bundle, falling back to the cached valid map."""
+        now = time.monotonic()
+        mode_changed = streaming != self._streaming
+        self._streaming = streaming
+        if (
+            not mode_changed
+            and self._current is not None
+            and self._last_attempt is not None
+            and now - self._last_attempt < self._next_refresh_delay(streaming)
+        ):
+            return self._current
+        self._last_attempt = now
+
+        try:
+            encoded = await self._async_fetch(streaming=streaming)
+            if encoded is None:
+                if self._current is None:
+                    raise MapSourceError("Map source returned no initial snapshot")
+                self._last_error = None
+                self._consecutive_failures = 0
+                return self._current
+            loaded = await self._hass.async_add_executor_job(
+                decode_map_bundle,
+                encoded,
+                self._device_id,
+            )
+            _reject_future_snapshot(loaded)
+            if self._current is None or loaded.snapshot_id != self._current.snapshot_id:
+                await self._hass.async_add_executor_job(
+                    write_cached_bundle,
+                    self._cache_file,
+                    encoded,
+                )
+            self._current = loaded
+            self._last_error = None
+            self._consecutive_failures = 0
+            return loaded
+        except (
+            aiohttp.ClientError,
+            asyncio.TimeoutError,
+            MapDecodeError,
+            MapSourceError,
+            OSError,
+        ) as exc:
+            self._consecutive_failures += 1
+            self._last_error = _safe_error_message(exc)
+
+        if self._current is not None:
+            return self._current
+
+        try:
+            encoded = await self._hass.async_add_executor_job(
+                read_cached_bundle,
+                self._cache_file,
+            )
+            self._current = await self._hass.async_add_executor_job(
+                decode_map_bundle,
+                encoded,
+                self._device_id,
+            )
+            _reject_future_snapshot(self._current)
+        except (MapDecodeError, MapSourceError, OSError) as exc:
+            raise MapSourceError(
+                "No valid E15 map is available from the source or cache"
+            ) from exc
+        return self._current
+
+    def _next_refresh_delay(self, streaming: bool) -> float:
+        interval = (
+            MAP_STREAM_REFRESH_INTERVAL if streaming else MAP_REFRESH_INTERVAL
+        ).total_seconds()
+        if not self._consecutive_failures:
+            return interval
+        return max(interval, min(2**self._consecutive_failures, 60))
+
+    async def _async_fetch(self, *, streaming: bool) -> bytes | None:
+        session = async_get_clientsession(self._hass)
+        ssl: bool | aiohttp.Fingerprint = True
+        if self._settings.certificate_fingerprint is not None:
+            ssl = aiohttp.Fingerprint(self._settings.certificate_fingerprint)
+
+        headers = {
+            "Authorization": f"Bearer {self._settings.access_token}",
+            "Accept": MAP_BUNDLE_CONTENT_TYPE,
+            MAP_MODE_HEADER: MAP_MODE_STREAM if streaming else MAP_MODE_IDLE,
+        }
+        if self._etag is not None:
+            headers["If-None-Match"] = self._etag
+        async with session.get(
+            f"{self._settings.base_url}/v1/map",
+            headers=headers,
+            ssl=ssl,
+            timeout=_REQUEST_TIMEOUT,
+        ) as response:
+            if response.status == 304:
+                return None
+            if response.status == 401:
+                raise MapSourceError("Map source rejected authentication")
+            if response.status == 503:
+                raise MapSourceError("Map source has no complete snapshot")
+            if response.status != 200:
+                raise MapSourceError(f"Map source returned HTTP {response.status}")
+
+            content_type = response.headers.get("Content-Type", "").split(
+                ";",
+                maxsplit=1,
+            )[0]
+            if content_type != MAP_BUNDLE_CONTENT_TYPE:
+                raise MapSourceError("Map source returned an unexpected content type")
+            if (
+                response.content_length is not None
+                and response.content_length > _MAX_BUNDLE_SIZE
+            ):
+                raise MapSourceError("Map source response exceeds 16 MiB")
+
+            encoded = await response.content.read(_MAX_BUNDLE_SIZE + 1)
+            if len(encoded) > _MAX_BUNDLE_SIZE:
+                raise MapSourceError("Map source response exceeds 16 MiB")
+            etag = response.headers.get("ETag")
+            if etag and len(etag) <= 256 and "\n" not in etag and "\r" not in etag:
+                self._etag = etag
+            return encoded
+
+
+def decode_map_bundle(data: bytes, expected_device_id: str) -> LoadedMap:
+    """Validate and decode an untrusted map bundle."""
+    if not data:
+        raise MapSourceError("Map bundle is empty")
+    if len(data) > _MAX_BUNDLE_SIZE:
+        raise MapSourceError("Map bundle exceeds 16 MiB")
+
+    try:
+        with ZipFile(BytesIO(data), mode="r") as archive:
+            members = archive.infolist()
+            names = [member.filename for member in members]
+            if len(names) != len(set(names)):
+                raise MapSourceError("Map bundle contains duplicate members")
+            if frozenset(names) != _EXPECTED_MEMBERS:
+                raise MapSourceError("Map bundle contains unexpected or missing files")
+            for member in members:
+                _validate_member(member)
+
+            manifest = _decode_manifest(archive.read(_MANIFEST_FILENAME))
+            payloads = {filename: archive.read(filename) for filename in _MAP_FILENAMES}
+    except BadZipFile as exc:
+        raise MapSourceError("Map bundle is not a valid ZIP archive") from exc
+
+    if manifest.get("schema_version") != _SCHEMA_VERSION:
+        raise MapSourceError("Map bundle uses an unsupported schema version")
+    device_id = manifest.get("device_id")
+    if device_id != expected_device_id:
+        raise MapSourceError("Map bundle belongs to a different device")
+
+    captured_at_raw = manifest.get("captured_at")
+    if not isinstance(captured_at_raw, int) or isinstance(captured_at_raw, bool):
+        raise MapSourceError("Map bundle captured_at must be an integer")
+    try:
+        captured_at = datetime.fromtimestamp(captured_at_raw, tz=UTC)
+    except (OverflowError, OSError, ValueError) as exc:
+        raise MapSourceError("Map bundle captured_at is invalid") from exc
+
+    files = manifest.get("files")
+    if not isinstance(files, dict) or set(files) != set(_MAP_FILENAMES):
+        raise MapSourceError("Map bundle file inventory is invalid")
+    for filename, payload in payloads.items():
+        if not payload or len(payload) > _MAX_MAP_FILE_SIZE:
+            raise MapSourceError(f"Map payload {filename} has an invalid size")
+        metadata = files.get(filename)
+        if not isinstance(metadata, dict):
+            raise MapSourceError(f"Map metadata for {filename} is invalid")
+        expected_hash = metadata.get("sha256")
+        if (
+            metadata.get("size") != len(payload)
+            or not isinstance(expected_hash, str)
+            or not _SHA256_PATTERN.fullmatch(expected_hash)
+            or hashlib.sha256(payload).hexdigest() != expected_hash
+        ):
+            raise MapSourceError(f"Map payload {filename} does not match its manifest")
+
+    snapshot_id = manifest.get("snapshot_id")
+    if (
+        not isinstance(snapshot_id, str)
+        or not _SHA256_PATTERN.fullmatch(snapshot_id)
+        or snapshot_id != _snapshot_digest(payloads)
+    ):
+        raise MapSourceError("Map bundle snapshot identifier is invalid")
+
+    return LoadedMap(
+        snapshot_id=snapshot_id,
+        captured_at=captured_at,
+        snapshot=parse_map_snapshot(
+            payloads[_MAP_FILENAME],
+            payloads[_CLEAN_PATH_FILENAME],
+            payloads[_NAV_PATH_FILENAME],
+        ),
+    )
+
+
+def read_cached_bundle(path: Path) -> bytes:
+    """Read one bounded latest-good bundle from disk."""
+    metadata = path.stat()
+    if not path.is_file() or metadata.st_size <= 0:
+        raise MapSourceError("Cached map bundle is empty or not a file")
+    if metadata.st_size > _MAX_BUNDLE_SIZE:
+        raise MapSourceError("Cached map bundle exceeds 16 MiB")
+    return path.read_bytes()
+
+
+def write_cached_bundle(path: Path, data: bytes) -> None:
+    """Atomically replace the single latest-good bundle."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
+    temporary = path.with_name(f".{path.name}-{uuid.uuid4().hex}")
+    try:
+        with temporary.open("xb") as stream:
+            os.chmod(temporary, 0o600)
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _validate_member(member: ZipInfo) -> None:
+    if member.filename not in _EXPECTED_MEMBERS:
+        raise MapSourceError("Map bundle contains an unsupported path")
+    if member.is_dir() or member.flag_bits & 0x1:
+        raise MapSourceError("Map bundle contains a directory or encrypted member")
+    if member.compress_type != ZIP_STORED:
+        raise MapSourceError("Map bundle members must be stored without compression")
+    maximum = 64 * 1024 if member.filename == _MANIFEST_FILENAME else _MAX_MAP_FILE_SIZE
+    if member.file_size <= 0 or member.file_size > maximum:
+        raise MapSourceError(f"Map bundle member {member.filename} has an invalid size")
+
+
+def _decode_manifest(data: bytes) -> dict[str, object]:
+    try:
+        decoded = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise MapSourceError("Map bundle manifest is not valid JSON") from exc
+    if not isinstance(decoded, dict):
+        raise MapSourceError("Map bundle manifest must be an object")
+    return decoded
+
+
+def _snapshot_digest(payloads: dict[str, bytes]) -> str:
+    digest = hashlib.sha256()
+    for filename in _MAP_FILENAMES:
+        payload = payloads[filename]
+        digest.update(filename.encode("ascii"))
+        digest.update(len(payload).to_bytes(8, byteorder="big"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def _safe_error_message(exc: BaseException) -> str:
+    if isinstance(exc, aiohttp.ServerFingerprintMismatch):
+        return "Map source certificate fingerprint does not match"
+    if isinstance(exc, aiohttp.ClientConnectorCertificateError):
+        return "Map source TLS certificate validation failed"
+    if isinstance(exc, aiohttp.ClientConnectorError):
+        return "Map source connection failed"
+    if isinstance(exc, asyncio.TimeoutError):
+        return "Map source request timed out"
+    if isinstance(exc, MapSourceError):
+        return str(exc)[:240]
+    if isinstance(exc, MapDecodeError):
+        return "Map source returned malformed E15 data"
+    if isinstance(exc, OSError):
+        return "Map cache I/O failed"
+    if isinstance(exc, aiohttp.ClientError):
+        return "Map source transport failed"
+    return "Map acquisition failed"
+
+
+def _reject_future_snapshot(loaded: LoadedMap) -> None:
+    if loaded.captured_at > datetime.now(tz=UTC) + timedelta(minutes=5):
+        raise MapSourceError("Map source returned a future-dated snapshot")

--- a/custom_components/eufy_robomow/number.py
+++ b/custom_components/eufy_robomow/number.py
@@ -49,6 +49,9 @@ async def async_setup_entry(
 ) -> None:
     coordinator: EufyMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
 
+    if not coordinator.control_enabled:
+        return
+
     entities: list[NumberEntity] = [
         EufyCutHeightNumber(coordinator, entry),
         EufyVolumeNumber(coordinator, entry),

--- a/custom_components/eufy_robomow/select.py
+++ b/custom_components/eufy_robomow/select.py
@@ -9,7 +9,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DOMAIN,
@@ -32,7 +31,7 @@ async def async_setup_entry(
     """Set up select entities — cloud settings only (require cloud credentials)."""
     coordinator: EufyMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    if coordinator.cloud_client is not None:
+    if coordinator.control_enabled and coordinator.cloud_client is not None:
         async_add_entities(
             [
                 EufyPathDistanceSelect(coordinator, entry),
@@ -68,9 +67,7 @@ class EufyCloudSelect(SelectEntity):
         return f"{self._entry.data[CONF_DEVICE_ID]}_{self._setting_name}"
 
     @property
-    def device_info(self):
-        from homeassistant.helpers.device_registry import DeviceInfo
-
+    def device_info(self) -> DeviceInfo:
         return DeviceInfo(
             identifiers={(DOMAIN, self._entry.data[CONF_DEVICE_ID])},
         )

--- a/custom_components/eufy_robomow/sensor.py
+++ b/custom_components/eufy_robomow/sensor.py
@@ -42,11 +42,11 @@ DP125_SECONDS_PER_UNIT = 6.6
 
 # DPS that should NOT be exposed as generic sensors (already have dedicated entities)
 EXCLUDED_DPS = {
-    "1",    # Task active      → used internally by lawn_mower entity
-    "2",    # Paused           → used internally by lawn_mower entity
-    "8",    # Battery          → dedicated Battery sensor
-    "26",   # Volume           → dedicated Number entity
-    "47",   # Child protection → dedicated Switch entity
+    "1",  # Task active      → used internally by lawn_mower entity
+    "2",  # Paused           → used internally by lawn_mower entity
+    "8",  # Battery          → dedicated Battery sensor
+    "26",  # Volume           → dedicated Number entity
+    "47",  # Child protection → dedicated Switch entity
     "101",  # Rain detection   → dedicated Switch entity
     "109",  # Signal strength  → dedicated Sensor entity
     "110",  # Cut height       → dedicated Number entity
@@ -65,11 +65,11 @@ EXCLUDED_DPS = {
 # Cloud setting keys that have dedicated entities — exclude from generic sensors
 # to avoid duplicating values that are already well-represented.
 CLOUD_ENTITY_KEYS = {
-    "cloud_path_mm",       # Path distance select (8/10/12 cm)
+    "cloud_path_mm",  # Path distance select (8/10/12 cm)
     "cloud_travel_speed",  # Travel speed select
-    "cloud_blade_speed",   # Blade speed select
-    "cloud_edge_mm",       # Edge distance number
-    "cloud_pad_direction", # Pad direction number
+    "cloud_blade_speed",  # Blade speed select
+    "cloud_edge_mm",  # Edge distance number
+    "cloud_pad_direction",  # Pad direction number
 }
 
 # Pre-seed set is now empty — all previously known DPs have dedicated entities.
@@ -147,6 +147,7 @@ SENSORS: tuple[EufySensorDescription, ...] = (
 
 # ── Shared protobuf helpers ────────────────────────────────────────────────────
 
+
 def _read_varint(data: bytes, pos: int) -> tuple[int, int]:
     """Read a protobuf varint from *data* at *pos*. Returns (value, new_pos)."""
     result = shift = 0
@@ -182,11 +183,11 @@ def _proto_flat(data: bytes) -> dict[int, Any]:
                 fields[fn] = data[pos : pos + length]
                 pos += length
             elif wt == 1:
-                pos += 8   # fixed64 — skip
+                pos += 8  # fixed64 — skip
             elif wt == 5:
-                pos += 4   # fixed32 / float — skip
+                pos += 4  # fixed32 / float — skip
             else:
-                break      # unknown wire type — bail out
+                break  # unknown wire type — bail out
         except Exception:
             break
     return fields
@@ -219,9 +220,9 @@ def _decode_dp113(raw_blob: str | None) -> _Dp113Result:
         return None, None, None
 
     f = _proto_flat(data)
-    total   = f.get(2)   # zone planned area
-    covered = f.get(3)   # area covered this session
-    dist    = f.get(5)   # distance in metres
+    total = f.get(2)  # zone planned area
+    covered = f.get(3)  # area covered this session
+    dist = f.get(5)  # distance in metres
 
     # field2 must be a positive int for data to be meaningful
     if not isinstance(total, int) or total <= 0:
@@ -230,7 +231,7 @@ def _decode_dp113(raw_blob: str | None) -> _Dp113Result:
     return (
         total,
         covered if isinstance(covered, int) else None,
-        dist    if isinstance(dist,    int) else None,
+        dist if isinstance(dist, int) else None,
     )
 
 
@@ -266,6 +267,8 @@ async def async_setup_entry(
     entities.append(EufyMowingProgressSensor(coordinator, entry))
     entities.append(EufySessionDistanceSensor(coordinator, entry))
     entities.append(EufyCoverageSensor(coordinator, entry))
+    if coordinator.session_store:
+        entities.append(EufySessionHistorySensor(coordinator, entry, coordinator.session_store))
     async_add_entities(entities)
 
     # Track which DP IDs already have a generic sensor so we never duplicate.
@@ -328,7 +331,7 @@ def _decode_blob(value: Any) -> str:
 
             # Return hex representation for binary data
             return f"<blob ({len(decoded)} bytes)> {decoded.hex()}"
-        except (binascii.Error, ValueError):
+        except binascii.Error, ValueError:
             # Not base64, return as-is
             pass
 
@@ -515,3 +518,33 @@ class EufyGenericSensor(CoordinatorEntity[EufyMowerCoordinator], SensorEntity):
     def _handle_update(self) -> None:
         """Handle coordinator update."""
         self.async_write_ha_state()
+
+
+class EufySessionHistorySensor(CoordinatorEntity[EufyMowerCoordinator], SensorEntity):
+    """Expose a bounded view; the private store owns full session summaries."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Mowing Session"
+    _attr_icon = "mdi:history"
+    _unrecorded_attributes = frozenset({"current_session", "recent_sessions"})
+
+    def __init__(self, coordinator, entry, sessions) -> None:
+        super().__init__(coordinator)
+        self._sessions = sessions
+        self._attr_unique_id = f"{entry.data[CONF_DEVICE_ID]}_mowing_session"
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, entry.data[CONF_DEVICE_ID])})
+
+    @property
+    def native_value(self) -> str:
+        current = self._sessions.history.current
+        return current["phase"] if current else "idle"
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        history = self._sessions.history
+        return {
+            "current_session": history.current,
+            "recent_sessions": history.recent[:20],
+            "stored_sessions": len(history.recent),
+            "area_unit": "raw",
+        }

--- a/custom_components/eufy_robomow/sensor.py
+++ b/custom_components/eufy_robomow/sensor.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import base64
 import binascii
 import logging
-import struct
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -33,7 +32,6 @@ from .const import (
     DP_SIGNAL,
     DP_LIVE_VIEW,
     DP_TASK_ACTIVE,
-    GENERIC_SENSOR_PREFIX,
 )
 from .coordinator import EufyMowerCoordinator
 
@@ -153,7 +151,8 @@ def _read_varint(data: bytes, pos: int) -> tuple[int, int]:
     """Read a protobuf varint from *data* at *pos*. Returns (value, new_pos)."""
     result = shift = 0
     while pos < len(data):
-        b = data[pos]; pos += 1
+        b = data[pos]
+        pos += 1
         result |= (b & 0x7F) << shift
         if not (b & 0x80):
             break
@@ -173,13 +172,15 @@ def _proto_flat(data: bytes) -> dict[int, Any]:
     while pos < len(data):
         try:
             tag, pos = _read_varint(data, pos)
-            fn = tag >> 3; wt = tag & 7
+            fn = tag >> 3
+            wt = tag & 7
             if wt == 0:
                 val, pos = _read_varint(data, pos)
                 fields[fn] = val
             elif wt == 2:
                 length, pos = _read_varint(data, pos)
-                fields[fn] = data[pos:pos + length]; pos += length
+                fields[fn] = data[pos : pos + length]
+                pos += length
             elif wt == 1:
                 pos += 8   # fixed64 — skip
             elif wt == 5:
@@ -322,7 +323,7 @@ def _decode_blob(value: Any) -> str:
                 text = decoded.decode("utf-8")
                 if all(32 <= ord(c) < 127 or c in "\n\r\t" for c in text):
                     return f"<text> {text}"
-            except:
+            except UnicodeDecodeError:
                 pass
 
             # Return hex representation for binary data

--- a/custom_components/eufy_robomow/sessions.py
+++ b/custom_components/eufy_robomow/sessions.py
@@ -1,0 +1,146 @@
+"""Bounded, restart-safe session history without raw DPS or private geometry."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DP_PAUSED, DP_PROGRESS, RETURNING_THRESHOLD
+from .telemetry import task_active
+
+MAX_SESSIONS = 50
+MAX_OBSERVATION_GAP = 45
+
+
+class SessionHistory:
+    """Record observed task boundaries; never infer completion from lost connectivity."""
+
+    def __init__(self) -> None:
+        self.current: dict[str, Any] | None = None
+        self.recent: list[dict[str, Any]] = []
+        self._previous_at: datetime | None = None
+        self._previous_phase = "unknown"
+        self._previous_active: bool | None = None
+        self._previous_blob: str | None = None
+        self._accept_blob = False
+
+    def load(self, data: dict[str, Any]) -> None:
+        self.current = data.get("current")
+        self.recent = data.get("recent", [])[:MAX_SESSIONS]
+        if self.current:
+            self.current["observation_gap"] = True
+        # No continuity assumption after a restart.
+
+    def dump(self) -> dict[str, Any]:
+        return {"current": self.current, "recent": self.recent}
+
+    def observe(self, dps: dict[str, Any], now: datetime) -> bool:
+        from .sensor import _decode_dp113
+
+        active = task_active(dps)
+        if type(active) is not bool:
+            if self.current:
+                self.current["observation_gap"] = True
+            self._previous_at = None
+            return self.current is not None
+        blob = dps.get("113")
+        if active and self.current is None:
+            self.current = {
+                "id": uuid4().hex,
+                "started_at": now.isoformat(),
+                "start_observed": self._previous_active is False,
+                "last_observed_at": now.isoformat(),
+                "ended_at": None,
+                "end_observed": False,
+                "mowing_seconds": 0.0,
+                "paused_seconds": 0.0,
+                "returning_seconds": 0.0,
+                "charging_seconds": 0.0,
+                "unknown_seconds": 0.0,
+                "pause_count": 0,
+                "observation_gap": self._previous_active is not False,
+                "area_raw": None,
+                "distance_m": None,
+                "progress": None,
+                "phase": "unknown",
+            }
+            self._previous_at = None
+            self._accept_blob = False
+        current = self.current
+        if current:
+            if self._previous_at is not None:
+                delta = max(0.0, (now - self._previous_at).total_seconds())
+                if delta > MAX_OBSERVATION_GAP:
+                    current["observation_gap"] = True
+                    current["unknown_seconds"] += delta
+                else:
+                    current[f"{self._previous_phase}_seconds"] += delta
+            phase = "unknown"
+            progress = dps.get(DP_PROGRESS)
+            if active:
+                if dps.get(DP_PAUSED) is True:
+                    phase = "paused"
+                elif dps.get(DP_PAUSED) is False:
+                    if progress == 100:
+                        phase = "charging"
+                    elif isinstance(progress, int) and RETURNING_THRESHOLD <= progress < 100:
+                        phase = "returning"
+                    elif progress == 0:
+                        phase = "mowing"
+                if phase == "paused" and self._previous_phase != "paused":
+                    current["pause_count"] += 1
+                # A blob left over from a previous task is not current progress.
+                if (
+                    blob is not None
+                    and self._previous_blob is not None
+                    and blob != self._previous_blob
+                ):
+                    self._accept_blob = True
+                if self._accept_blob and blob is not None:
+                    total, covered, distance = _decode_dp113(blob)
+                    if total is not None and covered is not None:
+                        current["area_raw"] = covered
+                        current["progress"] = round(min(100, max(0, covered / total * 100)), 1)
+                    if distance is not None:
+                        current["distance_m"] = distance
+            current["phase"] = phase
+            current["last_observed_at"] = now.isoformat()
+            if not active:
+                current["ended_at"] = now.isoformat()
+                current["end_observed"] = (
+                    self._previous_active is True
+                    and self._previous_at is not None
+                    and (now - self._previous_at).total_seconds() <= MAX_OBSERVATION_GAP
+                )
+                self.recent.insert(0, dict(current))
+                self.recent = self.recent[:MAX_SESSIONS]
+                self.current = None
+            self._previous_phase = phase
+        self._previous_at, self._previous_active = now, active
+        self._previous_blob = blob
+        return current is not None
+
+
+class SessionStore:
+    """Persist at most fifty summaries and the current observation."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        self.history = SessionHistory()
+        self.store: Store[dict[str, Any]] = Store(
+            hass, 1, f"eufy_robomow.sessions.{entry_id}", serialize_in_event_loop=True
+        )
+
+    async def async_load(self) -> None:
+        if data := await self.store.async_load():
+            self.history.load(data)
+
+    def observe(self, dps: dict[str, Any], now: datetime) -> None:
+        if self.history.observe(dps, now):
+            self.store.async_delay_save(self.history.dump, 5)
+
+    async def async_save(self) -> None:
+        await self.store.async_save(self.history.dump())

--- a/custom_components/eufy_robomow/strings.json
+++ b/custom_components/eufy_robomow/strings.json
@@ -28,6 +28,20 @@
       "already_configured": "This mower is already configured."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Eufy Robomow operating mode",
+        "description": "Observe-only disables every mower and settings write. Enable control only after read-only telemetry has been validated on your mower.",
+        "data": {
+          "operating_mode": "Operating mode"
+        },
+        "data_description": {
+          "operating_mode": "observe_only is the safe default; control enables physical mower commands and setting changes."
+        }
+      }
+    }
+  },
   "entity": {
     "lawn_mower": {
       "lawn_mower": {

--- a/custom_components/eufy_robomow/strings.json
+++ b/custom_components/eufy_robomow/strings.json
@@ -31,18 +31,30 @@
   "options": {
     "step": {
       "init": {
-        "title": "Eufy Robomow operating mode",
-        "description": "Observe-only disables every mower and settings write. Enable control only after read-only telemetry has been validated on your mower.",
+        "title": "Eufy Robomow options",
+        "description": "Observe-only disables mower and settings writes. The optional map source is always read-only; leave its URL empty to disable the map entity.",
         "data": {
-          "operating_mode": "Operating mode"
+          "operating_mode": "Operating mode",
+          "map_source_url": "Map source HTTPS URL",
+          "map_certificate_fingerprint": "Certificate SHA-256 fingerprint (optional)"
         },
         "data_description": {
-          "operating_mode": "observe_only is the safe default; control enables physical mower commands and setting changes."
+          "operating_mode": "observe_only is the safe default; control enables physical mower commands and setting changes.",
+          "map_source_url": "Base URL of a compatible E15 map source.",
+          "map_certificate_fingerprint": "Optional pin for a private or self-signed TLS certificate."
         }
       }
+    },
+    "error": {
+      "invalid_map_source": "The map source URL or certificate fingerprint is invalid."
     }
   },
   "entity": {
+    "image": {
+      "map": {
+        "name": "Map"
+      }
+    },
     "lawn_mower": {
       "lawn_mower": {
         "name": "Mower"

--- a/custom_components/eufy_robomow/switch.py
+++ b/custom_components/eufy_robomow/switch.py
@@ -44,6 +44,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: EufyMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    if not coordinator.control_enabled:
+        return
     async_add_entities(
         [
             EufySwitch(coordinator, entry, key, dp, name, icon, enabled)

--- a/custom_components/eufy_robomow/telemetry.py
+++ b/custom_components/eufy_robomow/telemetry.py
@@ -1,0 +1,19 @@
+"""Interpret task flags in complete E15 local status responses."""
+
+from typing import Any
+
+
+def task_active(dps: dict[str, Any]) -> bool | None:
+    """An idle E15 omits DP1/DP2 until the first command after a connection reset.
+
+    Only apply this observed idle convention to a complete status shape. Empty
+    responses and partial notifications remain unknown and never end a session.
+    Explicit flags always take precedence. This is not evidence of dock arrival.
+    """
+    value = dps.get("1")
+    if type(value) is bool:
+        return value
+    if "1" not in dps and "2" not in dps and {"8", "110", "118"} <= dps.keys():
+        if type(dps["8"]) is int and type(dps["110"]) is int and dps["118"] == 0:
+            return False
+    return None

--- a/custom_components/eufy_robomow/translations/en.json
+++ b/custom_components/eufy_robomow/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Eufy Robomow — Sign in",
-        "description": "Sign in with your Eufy account to discover your mower and unlock all cloud-managed settings (edge distance, path distance, travel speed, blade speed, pad direction).",
+        "description": "Sign in with your Eufy account to discover your mower and unlock cloud-managed settings.",
         "data": {
           "eufy_email": "Eufy account email",
           "eufy_password": "Eufy account password"
@@ -11,7 +11,7 @@
       },
       "device": {
         "title": "Eufy Robomow — Select mower",
-        "description": "Found {device_count} device(s) in your account. Select your mower and enter its local IP address (check your router's DHCP table if unsure).",
+        "description": "Found {device_count} device(s). Select your mower and enter its local IP address.",
         "data": {
           "device_id": "Mower",
           "host": "IP address of the mower"
@@ -19,13 +19,27 @@
       }
     },
     "error": {
-      "cannot_connect": "Cannot connect to the mower. Check the IP address and make sure it is on WiFi.",
+      "cannot_connect": "Cannot connect to the mower. Check the IP address and Wi-Fi connection.",
       "invalid_auth": "Could not sign in. Check your email and password.",
       "no_devices": "No compatible devices found in this account.",
       "unknown": "Unexpected error. Check the Home Assistant logs for details."
     },
     "abort": {
       "already_configured": "This mower is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Eufy Robomow operating mode",
+        "description": "Observe-only disables every mower and settings write. Enable control only after read-only telemetry has been validated on your mower.",
+        "data": {
+          "operating_mode": "Operating mode"
+        },
+        "data_description": {
+          "operating_mode": "observe_only is the safe default; control enables physical mower commands and setting changes."
+        }
+      }
     }
   },
   "entity": {
@@ -35,19 +49,19 @@
       }
     },
     "sensor": {
-      "battery":     { "name": "Battery" },
-      "mowed_area":  { "name": "Mowed Area" },
-      "progress":    { "name": "Progress" },
-      "network":     { "name": "Network" }
+      "battery": { "name": "Battery" },
+      "mowed_area": { "name": "Mowed Area" },
+      "progress": { "name": "Progress" },
+      "network": { "name": "Network" }
     },
     "number": {
-      "cut_height":    { "name": "Cut Height" },
+      "cut_height": { "name": "Cut Height" },
       "edge_distance": { "name": "Edge Distance" },
       "pad_direction": { "name": "Pad Direction" }
     },
     "select": {
-      "travel_speed":  { "name": "Travel Speed" },
-      "blade_speed":   { "name": "Blade Speed" },
+      "travel_speed": { "name": "Travel Speed" },
+      "blade_speed": { "name": "Blade Speed" },
       "path_distance": { "name": "Path Distance" }
     }
   }

--- a/custom_components/eufy_robomow/translations/en.json
+++ b/custom_components/eufy_robomow/translations/en.json
@@ -31,18 +31,30 @@
   "options": {
     "step": {
       "init": {
-        "title": "Eufy Robomow operating mode",
-        "description": "Observe-only disables every mower and settings write. Enable control only after read-only telemetry has been validated on your mower.",
+        "title": "Eufy Robomow options",
+        "description": "Observe-only disables mower and settings writes. The optional map source is always read-only; leave its URL empty to disable the map entity.",
         "data": {
-          "operating_mode": "Operating mode"
+          "operating_mode": "Operating mode",
+          "map_source_url": "Map source HTTPS URL",
+          "map_certificate_fingerprint": "Certificate SHA-256 fingerprint (optional)"
         },
         "data_description": {
-          "operating_mode": "observe_only is the safe default; control enables physical mower commands and setting changes."
+          "operating_mode": "observe_only is the safe default; control enables physical mower commands and setting changes.",
+          "map_source_url": "Base URL of a compatible E15 map source.",
+          "map_certificate_fingerprint": "Optional pin for a private or self-signed TLS certificate."
         }
       }
+    },
+    "error": {
+      "invalid_map_source": "The map source URL or certificate fingerprint is invalid."
     }
   },
   "entity": {
+    "image": {
+      "map": {
+        "name": "Map"
+      }
+    },
     "lawn_mower": {
       "lawn_mower": {
         "name": "Mower"

--- a/docs/architecture/0001-adopt-github-fork.md
+++ b/docs/architecture/0001-adopt-github-fork.md
@@ -1,0 +1,26 @@
+# ADR 0001: Adopt the existing GitHub fork as the functional base
+
+Status: accepted (private development)
+
+## Decision
+
+Development continues from `keesmod/eufy-robomow-ha`, which currently preserves the history of `jnicolaes/eufy-robomow-ha`. The separate private GitLab project remains the tracker and protocol-evidence repository; its existing history is not rewritten.
+
+The integration defaults to `observe_only`. Physical commands and setting writes require an explicit switch to `control` in Home Assistant's integration options.
+
+## Rationale
+
+The adopted code already implements Eufy login, local-key discovery, TinyTuya 3.5 polling, mower controls, telemetry, and several settings. Building those layers again would add risk and delay. Safety controls, typed boundaries, verification, and missing app features can be added incrementally around the existing behavior.
+
+## Provenance and licensing boundary
+
+The upstream repository does not currently declare a software license. GitHub's fork mechanism is used as the development base, but source is not mirrored into the GitLab repository or redistributed under another license. Contributions added here must have clear provenance. Publication and relicensing require a separate licensing decision.
+
+Other public forks may be used only as feature and behavior checklists. Their implementation details are not copied unless their licensing and provenance permit it.
+
+## Consequences
+
+- The first delivery slice hardens existing behavior instead of recreating it.
+- HACS publication remains deferred.
+- Credential lifecycle, command acknowledgement, state normalization, schedules, zones, and maps remain separate reviewable slices.
+- Rollback is a branch reset/removal; no live system is changed by this decision.

--- a/docs/architecture/0002-github-development.md
+++ b/docs/architecture/0002-github-development.md
@@ -1,0 +1,27 @@
+# ADR 0002: Continue development on GitHub
+
+Status: accepted by the repository owner, 2026-09-06.
+
+`keesmod/eufy-robomow-ha` is the development source of truth. Use GitHub issues,
+pull requests and Actions for ongoing work. Port the dashboard, confirmed command
+handling, session history and optional planning package onto the existing GitHub
+history. Preserve the public map-source API and its authentication and config
+options; do not replace it with the private deployment's helper interface.
+
+The earlier GitLab checkout remains local reference material. Do not merge its
+private history, household configuration or raw observations into this public
+repository. The private P2P runtime and vendor binaries remain outside this
+publication. Existing attribution and licensing status remain unchanged; this
+migration is not a release or a new license grant.
+
+CI runs on hosted GitHub runners with read-only repository permissions. It covers
+Python quality/types/tests, frontend tests, Hassfest, runtime dependency audit
+and source secret scanning. CI never deploys to Home Assistant or operates a
+mower. Secret-scan exceptions are limited to exact inherited application constants
+and exact synthetic test values in their respective files.
+
+The supervised source implementation was validated on an E15 with start, pause
+and dock telemetry plus user observation of the physical outcomes. That evidence
+does not establish zone commands, resume-specific behavior or a naturally timed
+automatic session. The public port requires its own automated checks; it does
+not imply that this public build has been deployed to the private installation.

--- a/docs/map-preview.svg
+++ b/docs/map-preview.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="900" viewBox="0 0 720 900" role="img">
+  <title>Synthetic Eufy E15 map preview</title>
+  <defs>
+    <clipPath id="mowing-boundary-clip"><polygon points="149.88,147.55 391.84,147.55 404.57,230.33 601.96,243.06 672.00,319.47 627.43,408.61 652.90,516.86 570.12,593.27 506.45,586.90 474.61,733.35 334.53,733.35 321.80,580.53 188.08,561.43 149.88,472.29 175.35,357.67" /></clipPath>
+  </defs>
+  <rect class="background" width="720" height="900" />
+  <style>
+    .background { fill: #020505; }
+    .boundary { fill: #153f16; stroke: #49a6ff; stroke-width: 5; stroke-linejoin: round; }
+    .base-area { fill: #347f91; fill-opacity: .9; stroke: #55aaff; stroke-width: 4; stroke-dasharray: 12 8; stroke-linejoin: round; }
+    .no-go-area { fill: #050607; stroke: #626a74; stroke-width: 2; stroke-linejoin: round; }
+    .pathway { fill: none; stroke: #ffbd00; stroke-width: 10; stroke-linecap: round; stroke-linejoin: round; }
+    .pathway-center { fill: none; stroke: #fff7cf; stroke-width: 1.5; stroke-dasharray: 8 8; stroke-linecap: round; }
+    .cleaned-area { opacity: .58; }
+    .cleaned-path { fill: none; stroke: #82967e; stroke-width: 54; stroke-linecap: round; stroke-linejoin: round; }
+    .mower-shadow { fill: #000; opacity: .6; }
+    .mower-wheel { fill: #25292d; stroke: #747b80; stroke-width: 1; }
+    .mower-body { fill: #8e9498; stroke: #eceff1; stroke-width: 1.5; }
+    .mower-panel { fill: #d1d4d6; stroke: #61676b; stroke-width: 1; }
+    .mower-accent { fill: #e34c56; }
+    .station-shadow { fill: #000; opacity: .55; }
+    .station-body { fill: #353a3f; stroke: #5c646a; stroke-width: 1.5; }
+    .station-top { fill: #484f55; }
+    .station-lightning { fill: #f4f7f8; }
+  </style>
+  <g>
+    <polygon class="boundary" points="149.88,147.55 391.84,147.55 404.57,230.33 601.96,243.06 672.00,319.47 627.43,408.61 652.90,516.86 570.12,593.27 506.45,586.90 474.61,733.35 334.53,733.35 321.80,580.53 188.08,561.43 149.88,472.29 175.35,357.67" />
+    <g class="cleaned-area" clip-path="url(#mowing-boundary-clip)">
+      <polyline class="cleaned-path" points="219.92,204.86 219.92,523.22" />
+      <polyline class="cleaned-path" points="270.86,523.22 270.86,204.86" />
+      <polyline class="cleaned-path" points="321.80,204.86 321.80,523.22" />
+      <polyline class="cleaned-path" points="372.73,523.22 372.73,262.16" />
+    </g>
+    <polygon class="base-area" points="302.69,707.88 423.67,707.88 423.67,752.45 302.69,752.45" />
+    <polygon class="no-go-area" points="506.45,300.37 551.02,294.00 570.12,338.57 525.55,360.86 493.71,332.20" />
+    <polyline class="pathway" points="48.00,453.18 168.98,453.18" />
+    <polyline class="pathway-center" points="48.00,453.18 168.98,453.18" />
+    <g class="charging-station" transform="translate(68.00 521.18)">
+      <ellipse class="station-shadow" cx="0" cy="4" rx="15" ry="24" />
+      <path class="station-body" d="M -11 -19 Q 0 -22 11 -19 L 10 19 Q 0 23 -10 19 Z" />
+      <path class="station-top" d="M -8 -15 Q 0 -18 8 -15 L 7 -8 Q 0 -11 -7 -8 Z" />
+      <path class="station-lightning" d="M 2 -3 L -5 7 L 0 7 L -3 15 L 7 4 L 2 4 Z" />
+    </g>
+    <g class="mower-marker" transform="translate(372.73 376.78) scale(.75)">
+      <ellipse class="mower-shadow" cx="0" cy="3" rx="17" ry="25" />
+      <rect class="mower-wheel" x="-17" y="-14" width="5" height="29" rx="2" />
+      <rect class="mower-wheel" x="12" y="-14" width="5" height="29" rx="2" />
+      <path class="mower-body" d="M -11 -20 Q 0 -25 11 -20 L 13 15 Q 0 23 -13 15 Z" />
+      <rect class="mower-panel" x="-7" y="-14" width="14" height="22" rx="4" />
+      <rect class="mower-accent" x="-2" y="-19" width="4" height="8" rx="2" />
+    </g>
+  </g>
+</svg>

--- a/docs/protocol-provenance.md
+++ b/docs/protocol-provenance.md
@@ -1,0 +1,31 @@
+# Protocol provenance policy
+
+Protocol knowledge enters this repository only through independently reproducible evidence.
+
+## Accepted evidence
+
+- Official Eufy documentation and user-visible app behavior.
+- Redacted observations from an owned E15: before/action/after state, timestamps, screenshots, packet metadata, and resulting mower or app state.
+- Synthetic fixtures derived from a confirmed field definition.
+- A third-party implementation only when its license and provenance explicitly permit reuse.
+
+## Confirmation levels
+
+- `hypothesis`: a plausible interpretation with insufficient evidence.
+- `observed`: seen once or twice and not yet safe to encode as a stable contract.
+- `confirmed`: independently reproduced at least three times on the recorded app and firmware versions.
+- `hardware-validated`: confirmed through supervised physical behavior, not only transport acknowledgement.
+
+Only confirmed facts belong in production constants and parsers. Physical commands additionally require hardware validation and rollback instructions.
+
+## Required capture context
+
+Record the Eufy app version, mower model, mower firmware, timezone, operating mode, and the exact user action for every series. Keep speculative observations in tracker issues until confirmed.
+
+## Redaction
+
+Never commit raw captures. Remove passwords, tokens, local keys, full device and account identifiers, serials, ICCIDs, MAC addresses, IP addresses, exact coordinates, and private lawn geometry. Replace stable values with documented synthetic placeholders so tests preserve structure without preserving identity.
+
+## Other repositories
+
+Unlicensed projects and forks may be used to enumerate features and design experiments. Do not copy or mechanically translate their implementation, constants, schemas, fixtures, or tests. Record independently reproduced facts in this repository's own evidence trail.

--- a/docs/protocol-provenance.md
+++ b/docs/protocol-provenance.md
@@ -29,3 +29,18 @@ Never commit raw captures. Remove passwords, tokens, local keys, full device and
 ## Other repositories
 
 Unlicensed projects and forks may be used to enumerate features and design experiments. Do not copy or mechanically translate their implementation, constants, schemas, fixtures, or tests. Record independently reproduced facts in this repository's own evidence trail.
+
+## Current map-position interpretation
+
+The E15 map record's field 8 and the latest clean-path position have been
+repeatedly observed against the iOS app, but their dual live-session semantics
+are not documented by Eufy or Tuya. The renderer therefore treats:
+
+- map-record field 8 as the idle mower pose;
+- the latest clean-path position as the live mower pose while mowing; and
+- map-record field 8 as the charging-station marker during that live view.
+
+This is an `observed` presentation rule, not a confirmed protocol contract. The
+fixed SVG marker offset is visual alignment for the renderer's fixed-size icons
+and is clamped to the canvas. None of these positions may be used for commands,
+safety decisions, virtual-fence writes, or other physical control.

--- a/docs/validation-2026-09-06.md
+++ b/docs/validation-2026-09-06.md
@@ -1,0 +1,48 @@
+# Home Assistant validation — 2026-09-06
+
+The GitHub implementation was installed on HA Core 2026.9.0 for a supervised E15
+test. All 24 deployed integration/resource files initially matched GitHub main
+at `3b0d8f8`. The earlier private installation was backed up before replacement;
+its map URL and certificate pin were migrated to the public option names with
+the existing derived authentication. Entity identities, dashboard, settings and
+session storage were preserved. No account details or private geometry are
+included in this record. App and firmware versions were not refreshed, so this
+does not establish behavior across firmware versions.
+
+With the owner present, the lawn clear, irrigation off, daylight and onboard
+rain/child protection enabled, the following standard HA service calls each
+returned HTTP 200 and were confirmed by fresh local device telemetry (UTC):
+
+| Action | Requested | Confirmed | Evidence |
+| --- | --- | --- | --- |
+| Start | 17:05:49 | 17:05:51 | Mowing reported |
+| Pause | 17:05:54 | 17:06:00 | Pause reported |
+| Resume | 17:06:03 | 17:06:04 | Mowing reported |
+| Pause | 17:06:07 | 17:06:14 | Pause reported |
+| Return | 17:06:17 | 17:06:19 | Task inactive |
+
+The owner separately confirmed observing the complete sequence and physical
+arrival at the charging station. The inactive-task flag alone does not prove
+arrival. No recovery fallback was needed. The session was persisted with two
+pauses, approximately 19 seconds observed mowing and nine seconds paused, with
+both session edges observed and no telemetry gap. Both stored sessions survived
+the subsequent restart.
+
+Live validation uncovered that `ImageEntity` defaults to no polling. The map
+loaded at setup but was not subsequently refreshed despite a configured polling
+interval. Explicitly enabling entity polling fixes the responsible surface.
+The regression test exercises Home Assistant's actual platform polling filter:
+it fails without the correction and passes with it, including the streaming-to-
+idle transition. The corrected installation's automatic reports advance without
+manual update calls or mower movement. Source fetches remain throttled to the
+existing five-minute idle/two-second active cadence.
+
+The browser loaded the actual map, zoomed to 150%, displayed current setting
+controls and both history rows; zoom was restored afterward. Both live
+configuration checks passed. The checked Eufy logs contained only the standard
+custom-integration loader warnings. Local validation passed 86 Python tests,
+Ruff and mypy; the four frontend tests had already passed for the unchanged card.
+
+Automatic mowing remains off. A naturally timed automatic session and zone/box/
+spot commands remain unvalidated. This test does not claim new zone support or
+complete unattended-operation validation.

--- a/docs/validation-2026-09-06.md
+++ b/docs/validation-2026-09-06.md
@@ -46,3 +46,28 @@ Ruff and mypy; the four frontend tests had already passed for the unchanged card
 Automatic mowing remains off. A naturally timed automatic session and zone/box/
 spot commands remain unvalidated. This test does not claim new zone support or
 complete unattended-operation validation.
+
+## Viewer-style dashboard revision
+
+Frontend 0.7.1 replaces the separate green visual theme with Home Assistant theme
+colors, simple cards and four native dashboard tabs: Maaier, Geschiedenis,
+Planning and Instellingen. The overview places the map beside the status/control
+card on desktop and stacks them on mobile. Controls precede the detailed metrics;
+settings use short Dutch display names without renaming entities. Existing cards
+without a `view` option retain their combined layout. The command service calls,
+confirmation prompt, freshness checks and read-only restrictions are unchanged.
+
+The live dashboard configuration and previous frontend were backed up before
+deployment. The configuration was saved and read back through Home Assistant's
+WebSocket API; the resource points to frontend 0.7.1. A core configuration check
+passed. No Core restart or physical test was needed for this presentation change.
+
+Validation passed 86 Python tests, Ruff and five frontend unit tests. An isolated
+browser checked all four sections plus the backward-compatible combined view,
+390-pixel overflow, canceled Start sending zero service calls and the unavailable
+settings state. In the actual HA browser, all four tabs rendered, all three saved
+sessions remained visible, the original planning values remained with automatic
+mowing off, and the settings still displayed their existing values. Desktop and
+390-pixel layouts were inspected; the temporary viewport override was reset.
+The deployed frontend checksum matches the final source. No mower or planning
+setting was changed by the browser checks.

--- a/docs/zone-control-research.md
+++ b/docs/zone-control-research.md
@@ -1,0 +1,90 @@
+# Zone mowing research — 2026-09-06
+
+The current integration has no validated zone command. Its private map helper
+only acquires maps; map geometry must not be treated as command support. The
+inherited source contains conflicting comments about DP154 (unknown purpose,
+old direction hypothesis, zone-mode hypothesis). None proves an E15 zone payload.
+
+Eufy's [E15/E18 multi-lawn support article](https://service.eufy.com/article-description/How-many-maps-can-the-E15-and-E18-Robot-Lawn-Mowers-support-Are-they-capable-of-working-on-multiple-lawns),
+checked 2026-09-06, confirms one map per base station with multiple lawns connected
+through Multi-Zone Pathway. This establishes multi-lawn mapping as a supported
+product feature. It does not supply area command identifiers, a transport schema,
+or evidence of which selectable areas exist on the owned mower. Multiple lawns,
+must-mow geometry and no-go geometry must remain distinct in this investigation.
+
+Tuya's [boundaryless lawn mower protocol documentation](https://developer.tuya.com/en/docs/iot-device-dev/rlm_mqtt_ble_func?id=Kfcwmf6m68j0v),
+updated 2026-06-29, describes a separate cloud-to-device mowing task interface,
+including area mowing. It also documents schedule and mowing-history interfaces.
+This is a credible research direction, not evidence that this E15 firmware uses
+that protocol or that its identifiers match the private map renderer.
+
+The private deployment's E15 decoder explicitly returns an empty `zones` collection. It
+decodes map-record field 26 as base areas, consistent with the earlier app/map
+comparison; these must not be relabelled as selectable mowing zones. The
+normalized map model retains a map identifier and geometry but has no validated
+area identifiers or names. Zone selection therefore requires evidence for both
+the command transport and the mapping of selectable areas to device identifiers.
+
+The helper's MQTT decoder accepts only protocol 302 P2P signaling and discards
+other protocols. It is not currently a zone-command observer, and the presence
+of an incoming subscription does not prove that app-originated commands are
+visible there. Keep this signaling boundary intact until the relevant transport
+is established. First confirm whether the installed Eufy app offers individual
+area selection and whether multiple areas exist; a paired comparison is not
+possible from the currently decoded map alone.
+
+The next evidence needed is a paired, supervised Eufy-app action for two known
+areas: record the transport and redacted structural differences, correlate the
+chosen area with the accepted task and actual mower destination, and establish
+map-generation binding. First compare read-only observations; do not guess writes
+from vacuum protocols, DP154 comments or SDK enum names. Retain app/firmware
+versions alongside the observation and keep raw captures on the private host.
+
+Only after proving that mapping should an area-select action be exposed. It must
+reject missing or stale map/area identifiers and must never fall back silently
+to mowing the entire lawn. Map editing, fence changes and remote driving remain
+outside this feature.
+
+## Next observation and acceptance evidence
+
+The user supplied an app screenshot on 2026-09-06 showing the four modes Entire,
+Zone, Box and Spot. Zone is selected and one numbered area is visible. This
+confirms an area-selection UI on the owned device; a visible label is not yet a
+device area identifier. The screenshot does not establish the total configured
+area count, app/firmware versions or command payload. Private map geometry and
+the screenshot itself are not stored in the repository.
+
+At 16:31:59 UTC the existing HA telemetry reported the mower idle. A separate,
+read-only cloud sample at 16:33:35 UTC contained 86 DPs. DP154 decoded as a
+two-byte protobuf containing an integer at field 3. That shape alone neither
+establishes a zone mode nor an area ID. A temporary baseline containing DPS only
+was saved mode 0600 in the Core container's `/tmp`; no credentials, raw DPS or
+geometry were copied to the workstation or repository. No mower command was
+sent. The screenshot and sample are not a synchronized mode-change comparison.
+
+The next requested app action is selecting Entire without pressing Start, then
+comparing the read-only cloud snapshot. Selection-only changes may be local to
+the app until Start is pressed; unchanged cloud data would leave the command
+mapping unresolved. One visible zone is enough for an initial Entire-versus-Zone
+comparison; validation across two area IDs remains conditional on a second
+existing selectable area.
+
+Before collecting a physical app-action comparison, confirm current app/firmware
+versions and the existing area inventory. Do not create or split
+areas merely to manufacture a test case: that would change the lawn map. If
+individual selection is unavailable, record that limitation rather than inventing
+an unsupported HA control.
+
+For an existing selector, distinguish selecting an area from starting its task.
+First inspect selection-only changes without sending HA commands. For each later
+supervised task, retain the initial state, selected area's private alias, request
+time, changed payload structure and device task response; repeat with a different
+existing area. Use host-private captures and publish only redacted structure.
+Local activity flags alone cannot establish which area was selected. A usable
+mapping needs both the app-selected area and matching device/task evidence.
+
+Implementation requires a stable area identifier, its relationship to the active
+map generation, a validated command and device acceptance/error semantics. Its
+tests must cover stale map IDs, removed/unknown areas, unavailable telemetry and
+rejected requests. Keep whole-lawn start separate. Confirm the physical destination
+under supervision before labelling area control physically validated.

--- a/docs/zone-control-research.md
+++ b/docs/zone-control-research.md
@@ -168,6 +168,54 @@ multi-area targeting, map/area identity binding or the Spot mode. Raw status
 captures remain private on the HA host; no credentials or lawn geometry are
 included here.
 
+## Area-identity investigation after the app task
+
+The owned device's cloud inventory response contains no product/DP schema. The
+cached raw map does contain one previously unused record at map-record field
+10, subfield 4. Its subfield 3 polygon exactly matches the complete boundary in
+field 10, subfield 3. Integer metadata subfields 4 and 6 both equal 1. These are
+candidate metadata fields, not established area IDs: neither has yet been varied
+or matched to an outbound task request. Map-record field 23 also contains nested
+metadata with a one-byte zero payload; its meaning is unknown. Do not assume UI
+label 1 maps to either a value of 1 or a zero-based value of 0.
+
+A fresh cloud baseline at 17:47:03.210187 UTC still reported Zone mode and a docked
+mower. The next non-motion comparison is deselecting the sole existing area while
+remaining in Zone mode. This isolates area selection from the already observed
+mode changes if the app permits an empty selection and transmits it. Cached map
+geometry and raw DP snapshots remain on the private HA host.
+
+At 17:49:08.341467 UTC, after the owner confirmed deselecting area 1 while staying
+in Zone, DP154 and DP155 matched the selected baseline. Of 86 DPs, only DP107 and
+DP152 differed. DP152 retained its nested fields 3 and 4 and gained top-level
+integer field 5 = 1. DP107 changed from a one-byte opaque value to integer field
+4 = 2. HA reported docked. This is an observed difference after deselection, not
+proof that either field contains an area identifier; background status changes
+remain possible. Re-selecting area 1 is the next comparison to test reversibility.
+
+At 17:51:15.049781 UTC, after the owner confirmed reselecting area 1, all 86 DPs
+matched the deselected sample. DP107 and DP152 did not revert to the initial
+selected baseline. The selected–deselected–selected comparison therefore does
+not establish either changed field as an area selector. Further identical
+status-polling/click cycles have no demonstrated information gain. The next
+evidence path is an app-originated request or independently identified area
+schema; an incoming MQTT subscription alone does not prove request visibility.
+
+A bounded passive observer was subsequently attached to the existing helper's
+receive callback. It retained the original relay filtering, subscriptions and
+publish behavior. The sampled decrypted traffic contained 21 protocol-302 P2P
+signaling messages and no DP fields. No user-confirmed app selection was received
+during that observation window, so this does not establish whether an app command
+would be visible on the connection. Payloads outside the existing device-key
+decoder were not inspected; absence of a decoded message is not proof of absence
+of traffic. Repeating status polling is still insufficient for area identity.
+
+The temporary observer and startup override were removed, the original relay
+source checksum remained unchanged, and normal idle map requests were restored.
+The authenticated helper status returned HTTP 200, healthy, zero consecutive
+failures and a fresh success timestamp after cleanup. No mower actuation occurred
+in this passive investigation.
+
 Implementation requires a stable area identifier, its relationship to the active
 map generation, a validated command and device acceptance/error semantics. Its
 tests must cover stale map IDs, removed/unknown areas, unavailable telemetry and

--- a/docs/zone-control-research.md
+++ b/docs/zone-control-research.md
@@ -83,6 +83,91 @@ existing area. Use host-private captures and publish only redacted structure.
 Local activity flags alone cannot establish which area was selected. A usable
 mapping needs both the app-selected area and matching device/task evidence.
 
+## Confirmed selection-only comparison
+
+On 2026-09-06 the owner confirmed selecting Entire without Start, followed by
+Zone and the visible area labelled 1, again without Start. Read-only cloud
+samples were acquired at 17:24:28.976761 UTC and 17:25:24.836711 UTC respectively.
+Both contained 86 DPs; HA reported the mower docked at each sample. Raw snapshots
+remain mode 0600 in the Core container's temporary directory, outside this repo.
+
+Exactly DP113, DP154 and DP155 differed, with no added or removed DP keys:
+
+- DP154 changed from a one-byte null sentinel to protobuf field 3, wire type 0,
+  integer 1. This is evidence of a selection-associated change. It does not yet
+  distinguish a Zone mode enum from an area identifier or establish a command.
+- DP155 retained the same five decoded settings. Its top-level field 7 (integer
+  80 in Entire) was absent in the Zone sample; the remaining parsed structure
+  matched. Do not interpret the omitted redundant path-distance field as an
+  area selector.
+- DP113 changed from fields 1 through 5 to field 1 only. This may reflect session
+  telemetry being cleared, but two snapshots do not establish its cause.
+
+At 17:27:45.553398 UTC, after the owner confirmed returning to Entire without
+Start, a third sample matched the original Entire sample exactly across all 86
+DPs. DP154 returned to the null sentinel and DP155 also returned to its original
+representation. HA again reported docked. This Entire–Zone 1–Entire comparison
+establishes a reversible association with the app selection; it still does not
+distinguish a mode enum from a selected-area identifier.
+
+At 17:29:26.936874 UTC, after the owner confirmed selecting Box without drawing
+a box or pressing Start, DP154 contained field 3, wire type 0, integer 2. Only
+DP113 and DP154 differed from the original Entire sample; all 86 DP keys remained
+present and DP155 matched Entire exactly. HA reported docked. The association
+Entire=null, Zone=1, Box=2 supports a mowing-mode interpretation of field 3,
+rather than treating its Zone value as the visible area's identifier. No box
+geometry was selected or captured in this test.
+
+The subsequent Spot selection attempt was rejected by the app with the owner's
+reported message, "spot is only available when the robot is outside the base
+station". A read-only sample at 17:30:46.196447 UTC matched the Box sample across
+all 86 DPs, including DP154 field 3 = 2; HA still reported docked. This proves no
+observed state change for the rejected attempt, not a Spot enum value. Do not
+assign Spot=3 by extrapolation or bypass the app's station restriction.
+
+Further area comparisons and supervised task acceptance are still required
+before adding a zone write. Confirm the number of existing selectable zones
+before choosing that comparison. No integration command or setting write was
+issued for these samples.
+
+The owner subsequently confirmed that only one area exists, labelled 1, and
+returned the app to Entire. A comparison between two distinct existing areas is
+therefore unavailable on this map. Do not create another area for testing or
+claim multi-area targeting from a single-area start. The next feasible evidence
+is observing a short app-originated Zone 1 task, with the existing HA return/pause
+path bounding its duration; this can establish mode/task association but may
+still leave the area identifier and command transport unresolved.
+
+## Supervised app-originated Zone 1 task
+
+The owner explicitly approved the short zone test with automatic HA return and
+pause as its recovery fallback. The first observer exited before arming because
+the app was already on Zone instead of Entire. The next observer accepted the
+observed Zone starting state and armed at 17:36:17.061131 UTC after checking idle
+state, fresh local telemetry, manual control mode, automatic planning off,
+irrigation off, daylight, sufficient battery and enabled rain/child protection.
+
+The owner pressed Start in the Eufy app with Zone 1 selected. HA reported mowing
+at 17:36:59.494308 UTC from fresh local telemetry dated 17:36:58.982397 UTC. A cloud
+sample at 17:36:59.541848 UTC retained DP154 field 3 = 1. Compared with the Zone
+selection-only sample, exactly DP1, DP103, DP107, DP113, DP143 and DP152 changed.
+DP1 became true; DP152 gained top-level integer field 1 = 1 while its two nested
+messages remained unchanged. These task-associated changes do not establish an
+area identifier. The observer read status; it did not capture the app's outbound
+request or establish which other fields the app sent.
+
+Twenty seconds after detecting activity, the observer requested the existing HA
+dock action. Its HTTP 200 response and fresh task-inactive confirmation were
+recorded at 17:37:30.996201 UTC. No pause fallback was needed, and the observer
+exited successfully. The owner separately confirmed physical departure and
+arrival back at the station. Task inactive alone is not evidence of arrival.
+
+This validates an app-originated task in the observed Zone mode on the owner's
+single-area map and the HA return path. It does not yet validate an HA zone write,
+multi-area targeting, map/area identity binding or the Spot mode. Raw status
+captures remain private on the HA host; no credentials or lawn geometry are
+included here.
+
 Implementation requires a stable area identifier, its relationship to the active
 map generation, a validated command and device acceptance/error semantics. Its
 tests must cover stale map IDs, removed/unknown areas, unavailable telemetry and

--- a/examples/dashboard.yaml
+++ b/examples/dashboard.yaml
@@ -1,0 +1,31 @@
+title: Grasmaaier
+views:
+  - title: Grasmaaier
+    path: overzicht
+    type: panel
+    cards:
+      - type: custom:eufy-mower-card
+        title: Grasmaaier
+        entity: lawn_mower.eufy_robomow_e15_mower
+        map: image.eufy_robomow_e15
+        session: sensor.eufy_robomow_e15_mowing_session
+        battery: sensor.eufy_robomow_e15_battery
+        progress: sensor.eufy_robomow_e15_mowing_progress
+        distance: sensor.eufy_robomow_e15_session_distance
+        area: sensor.eufy_robomow_e15_mowed_area
+        planner_reason: sensor.eufy_maaiplanning
+        settings:
+          - number.eufy_robomow_e15_cut_height
+          - select.eufy_robomow_e15_travel_speed
+          - select.eufy_robomow_e15_blade_speed
+          - select.eufy_robomow_e15_path_distance
+          - number.eufy_robomow_e15_pad_direction
+        planner_entities:
+          - sensor.eufy_maaiomstandigheden
+          - input_boolean.eufy_automatisch_maaien
+          - input_select.eufy_maaidagen
+          - input_datetime.eufy_maaivenster_start
+          - input_datetime.eufy_maaivenster_einde
+          - input_number.eufy_droogtijd_minuten
+          - input_number.eufy_maximale_sessieduur
+          - input_number.eufy_minimale_startbatterij

--- a/examples/dashboard.yaml
+++ b/examples/dashboard.yaml
@@ -1,31 +1,57 @@
 title: Grasmaaier
 views:
-  - title: Grasmaaier
-    path: overzicht
-    type: panel
-    cards:
-      - type: custom:eufy-mower-card
-        title: Grasmaaier
-        entity: lawn_mower.eufy_robomow_e15_mower
-        map: image.eufy_robomow_e15
-        session: sensor.eufy_robomow_e15_mowing_session
-        battery: sensor.eufy_robomow_e15_battery
-        progress: sensor.eufy_robomow_e15_mowing_progress
-        distance: sensor.eufy_robomow_e15_session_distance
-        area: sensor.eufy_robomow_e15_mowed_area
-        planner_reason: sensor.eufy_maaiplanning
-        settings:
-          - number.eufy_robomow_e15_cut_height
-          - select.eufy_robomow_e15_travel_speed
-          - select.eufy_robomow_e15_blade_speed
-          - select.eufy_robomow_e15_path_distance
-          - number.eufy_robomow_e15_pad_direction
-        planner_entities:
-          - sensor.eufy_maaiomstandigheden
-          - input_boolean.eufy_automatisch_maaien
-          - input_select.eufy_maaidagen
-          - input_datetime.eufy_maaivenster_start
-          - input_datetime.eufy_maaivenster_einde
-          - input_number.eufy_droogtijd_minuten
-          - input_number.eufy_maximale_sessieduur
-          - input_number.eufy_minimale_startbatterij
+- title: Maaier
+  path: overzicht
+  type: panel
+  cards:
+  - type: custom:eufy-mower-card
+    title: Grasmaaier
+    entity: lawn_mower.eufy_robomow_e15_mower
+    map: image.eufy_robomow_e15
+    session: sensor.eufy_robomow_e15_mowing_session
+    battery: sensor.eufy_robomow_e15_battery
+    progress: sensor.eufy_robomow_e15_mowing_progress
+    distance: sensor.eufy_robomow_e15_session_distance
+    area: sensor.eufy_robomow_e15_mowed_area
+    view: overview
+- title: Geschiedenis
+  path: geschiedenis
+  type: panel
+  cards:
+  - type: custom:eufy-mower-card
+    title: Grasmaaier
+    entity: lawn_mower.eufy_robomow_e15_mower
+    session: sensor.eufy_robomow_e15_mowing_session
+    view: history
+- title: Planning
+  path: planning
+  type: panel
+  cards:
+  - type: custom:eufy-mower-card
+    title: Grasmaaier
+    entity: lawn_mower.eufy_robomow_e15_mower
+    planner_reason: sensor.eufy_maaiplanning
+    planner_entities:
+    - sensor.eufy_maaiomstandigheden
+    - input_boolean.eufy_automatisch_maaien
+    - input_select.eufy_maaidagen
+    - input_datetime.eufy_maaivenster_start
+    - input_datetime.eufy_maaivenster_einde
+    - input_number.eufy_droogtijd_minuten
+    - input_number.eufy_maximale_sessieduur
+    - input_number.eufy_minimale_startbatterij
+    view: planning
+- title: Instellingen
+  path: instellingen
+  type: panel
+  cards:
+  - type: custom:eufy-mower-card
+    title: Grasmaaier
+    entity: lawn_mower.eufy_robomow_e15_mower
+    settings:
+    - number.eufy_robomow_e15_cut_height
+    - select.eufy_robomow_e15_travel_speed
+    - select.eufy_robomow_e15_blade_speed
+    - select.eufy_robomow_e15_path_distance
+    - number.eufy_robomow_e15_pad_direction
+    view: settings

--- a/examples/eufy_mower_planning.yaml
+++ b/examples/eufy_mower_planning.yaml
@@ -1,0 +1,320 @@
+# Example package: replace every example_* entity with your own source.
+# The sensor expects Buienalarm attributes.data: success, start, delta, precip.
+# Missing irrigation/radar entities intentionally prevent automatic mowing.
+# A new installation starts with automatic mowing off. Existing Eufy-app schedules
+# remain independent. No raw map or private account identifiers are stored here.
+input_boolean:
+  eufy_planning_ingesteld:
+    name: Eufy planning geïnitialiseerd
+    icon: mdi:check
+  eufy_automatisch_maaien:
+    name: Eufy automatisch maaien
+    icon: mdi:calendar-clock
+  eufy_planning_eigen_sessie:
+    name: Eufy door planning gestarte sessie
+    icon: mdi:robot-mower
+
+input_select:
+  eufy_maaidagen:
+    name: Eufy maaidagen
+    options: ["Ma / wo / vr", "Di / do / za", "Dagelijks", "Weekend"]
+    icon: mdi:calendar-week
+
+input_datetime:
+  eufy_maaivenster_start:
+    name: Eufy vroegste start
+    has_date: false
+    has_time: true
+  eufy_maaivenster_einde:
+    name: Eufy laatste start
+    has_date: false
+    has_time: true
+  eufy_laatste_natte_waarneming:
+    name: Eufy laatste regen of beregening
+    has_date: true
+    has_time: true
+  eufy_laatste_startpoging:
+    name: Eufy laatste automatische startpoging
+    has_date: true
+    has_time: true
+
+input_number:
+  eufy_droogtijd_minuten:
+    name: Eufy droogtijd na regen of beregening
+    min: 30
+    max: 240
+    step: 15
+    unit_of_measurement: min
+    mode: box
+  eufy_maximale_sessieduur:
+    name: Eufy maximale automatische sessieduur
+    min: 30
+    max: 120
+    step: 15
+    unit_of_measurement: min
+    mode: box
+  eufy_minimale_startbatterij:
+    name: Eufy minimale startbatterij
+    min: 40
+    max: 100
+    step: 5
+    unit_of_measurement: "%"
+    mode: box
+
+template:
+  - sensor:
+      - name: Eufy maaiomstandigheden
+        unique_id: eufy_maaiomstandigheden
+        icon: mdi:weather-partly-rainy
+        state: >-
+          {% set radar = state_attr('sensor.example_buienalarm_rain_data', 'data') %}
+          {% set t = as_timestamp(now()) %}
+          {% set duur = states('input_number.eufy_maximale_sessieduur') | float(90) * 60 %}
+          {% set start = radar.get('start', 0) | float(0) if radar is mapping else 0 %}
+          {% set stap = radar.get('delta', 0) | int(0) if radar is mapping else 0 %}
+          {% set regen = radar.get('precip', []) if radar is mapping else [] %}
+          {% set gepland = as_timestamp(states('input_datetime.example_irrigation_start'), none) %}
+          {% if not is_state('switch.example_irrigation_valve', 'off') or not is_state('input_boolean.example_irrigation_active', 'off') %}
+            Beregening actief of klepstatus onbekend
+          {% elif states('input_boolean.example_irrigation_planned') not in ['on', 'off'] %}
+            Beregeningsplanning onbekend
+          {% elif is_state('input_boolean.example_irrigation_planned', 'on') and (gepland is none or gepland < t + duur + 1800) %}
+            Beregening gepland binnen de maaisessie
+          {% elif radar is not mapping or not radar.get('success', false) or stap <= 0 or start > t + 300 or t - start > 1200 or regen is not sequence or regen | length < 2 %}
+            Regenverwachting ontbreekt of is verouderd
+          {% elif start + stap * (regen | length - 1) < t + duur %}
+            Regenverwachting dekt de hele maaisessie niet
+          {% else %}
+            {% set ns = namespace(nat=false, ongeldig=false) %}
+            {% for waarde in regen %}
+              {% set tijd = start + loop.index0 * stap %}
+              {% if tijd >= t - stap and tijd <= t + duur %}
+                {% if not is_number(waarde) or waarde | float(-1) < 0 %}
+                  {% set ns.ongeldig = true %}
+                {% elif waarde | float(0) > 0 %}
+                  {% set ns.nat = true %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+            {% if ns.ongeldig %}Regenverwachting bevat ongeldige metingen
+            {% elif ns.nat %}Regen gemeld of verwacht
+            {% else %}Droog volgens regenradar{% endif %}
+          {% endif %}
+        attributes:
+          bron: sensor.example_buienalarm_rain_data
+          bijgewerkt: "{{ now().isoformat() }}"
+      - name: Eufy maaiplanning
+        unique_id: eufy_maaiplanning
+        icon: mdi:calendar-clock
+        state: >-
+          {% set t = as_timestamp(now()) %}
+          {% set dagen = states('input_select.eufy_maaidagen') %}
+          {% set dag = now().weekday() %}
+          {% set maaidag = dagen == 'Dagelijks' or (dagen == 'Ma / wo / vr' and dag in [0,2,4]) or (dagen == 'Di / do / za' and dag in [1,3,5]) or (dagen == 'Weekend' and dag in [5,6]) %}
+          {% set begin = states('input_datetime.eufy_maaivenster_start') %}
+          {% set einde = states('input_datetime.eufy_maaivenster_einde') %}
+          {% set nat = as_timestamp(states('input_datetime.eufy_laatste_natte_waarneming'), none) %}
+          {% set poging = as_timestamp(states('input_datetime.eufy_laatste_startpoging'), 0) %}
+          {% set vers = as_timestamp(state_attr('lawn_mower.eufy_robomow_e15_mower', 'telemetry_updated_at'), 0) %}
+          {% if not is_state('input_boolean.eufy_automatisch_maaien', 'on') %}
+            Automatisch maaien staat uit
+          {% elif not is_state('input_boolean.eufy_planning_ingesteld', 'on') %}Planning wordt geïnitialiseerd
+          {% elif not maaidag %}Vandaag is geen ingestelde maaidag
+          {% elif begin in ['unknown','unavailable'] or einde in ['unknown','unavailable'] or begin >= einde %}Ongeldig maaivenster
+          {% elif now().strftime('%H:%M:%S') < begin %}Wacht tot {{ begin[:5] }}
+          {% elif now().strftime('%H:%M:%S') >= einde %}Maaivenster voor vandaag gesloten
+          {% elif poging | timestamp_custom('%Y-%m-%d') == now().strftime('%Y-%m-%d') %}Vandaag al een startpoging gedaan
+          {% elif not is_state('sun.sun', 'above_horizon') or as_timestamp(state_attr('sun.sun','next_setting'), 0) - t < states('input_number.eufy_maximale_sessieduur') | float(90) * 60 + 1800 %}Onvoldoende daglicht voor de maaisessie
+          {% elif t - vers > 45 or states('lawn_mower.eufy_robomow_e15_mower') in ['unknown','unavailable'] %}Maaierstatus ontbreekt of is verouderd
+          {% elif state_attr('lawn_mower.eufy_robomow_e15_mower', 'operating_mode') != 'control' %}Maaier staat op alleen observeren
+          {% elif not is_state('lawn_mower.eufy_robomow_e15_mower', 'docked') %}Maaier heeft al een actieve taak
+          {% elif states('sensor.eufy_robomow_e15_battery') | float(-1) < states('input_number.eufy_minimale_startbatterij') | float(80) %}Batterij onvoldoende geladen
+          {% elif not is_state('switch.eufy_robomow_e15_stop_on_rain_detection', 'on') or not is_state('switch.eufy_robomow_e15_child_protection', 'on') %}Regenstop of kinderbeveiliging niet bevestigd
+          {% elif not is_state('sensor.eufy_maaiomstandigheden', 'Droog volgens regenradar') %}{{ states('sensor.eufy_maaiomstandigheden') }}
+          {% elif nat is none or t - nat < states('input_number.eufy_droogtijd_minuten') | float(60) * 60 %}Wacht op droogtijd na regen, beregening of herstart
+          {% else %}Klaar om te maaien{% endif %}
+        attributes:
+          maaidagen: "{{ states('input_select.eufy_maaidagen') }}"
+          vroegste_start: "{{ states('input_datetime.eufy_maaivenster_start') }}"
+          laatste_start: "{{ states('input_datetime.eufy_maaivenster_einde') }}"
+          omstandigheden: "{{ states('sensor.eufy_maaiomstandigheden') }}"
+          eigen_sessie: "{{ is_state('input_boolean.eufy_planning_eigen_sessie', 'on') }}"
+
+script:
+  eufy_gepland_maaien:
+    alias: Eufy - geplande maaibeurt uitvoeren
+    mode: single
+    sequence:
+      - condition: state
+        entity_id: input_boolean.eufy_automatisch_maaien
+        state: "on"
+      - condition: state
+        entity_id: sensor.eufy_maaiplanning
+        state: Klaar om te maaien
+      # Record before sending: a timeout must never produce repeated starts.
+      - action: input_datetime.set_datetime
+        target:
+          entity_id: input_datetime.eufy_laatste_startpoging
+        data:
+          timestamp: "{{ as_timestamp(now()) }}"
+      - action: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.eufy_planning_eigen_sessie
+      - action: lawn_mower.start_mowing
+        target:
+          entity_id: lawn_mower.eufy_robomow_e15_mower
+
+automation:
+  - id: eufy_planning_initialiseren
+    alias: Eufy - eenmalige begininstellingen
+    mode: single
+    triggers:
+      - trigger: homeassistant
+        event: start
+    conditions:
+      - condition: state
+        entity_id: input_boolean.eufy_planning_ingesteld
+        state: "off"
+    actions:
+      - action: input_datetime.set_datetime
+        target:
+          entity_id: input_datetime.eufy_maaivenster_start
+        data:
+          time: "10:00:00"
+      - action: input_datetime.set_datetime
+        target:
+          entity_id: input_datetime.eufy_maaivenster_einde
+        data:
+          time: "15:00:00"
+      - action: input_number.set_value
+        target:
+          entity_id: input_number.eufy_droogtijd_minuten
+        data:
+          value: 60
+      - action: input_number.set_value
+        target:
+          entity_id: input_number.eufy_maximale_sessieduur
+        data:
+          value: 90
+      - action: input_number.set_value
+        target:
+          entity_id: input_number.eufy_minimale_startbatterij
+        data:
+          value: 80
+      - action: input_boolean.turn_on
+        target:
+          entity_id: input_boolean.eufy_planning_ingesteld
+
+  - id: eufy_planning_droogtijd
+    alias: Eufy - droogtijd na regen en beregening
+    mode: restart
+    triggers:
+      - trigger: homeassistant
+        event: start
+      - trigger: time_pattern
+        minutes: "/5"
+      - trigger: state
+        entity_id:
+          - switch.example_irrigation_valve
+          - input_boolean.example_irrigation_active
+          - sensor.eufy_maaiomstandigheden
+    conditions:
+      - condition: template
+        value_template: >-
+          {{ trigger.platform == 'homeassistant'
+             or not is_state('sensor.eufy_maaiomstandigheden', 'Droog volgens regenradar')
+             or not is_state('switch.example_irrigation_valve', 'off')
+             or not is_state('input_boolean.example_irrigation_active', 'off') }}
+    actions:
+      - action: input_datetime.set_datetime
+        target:
+          entity_id: input_datetime.eufy_laatste_natte_waarneming
+        data:
+          timestamp: "{{ as_timestamp(now()) }}"
+
+  - id: eufy_planning_start
+    alias: Eufy - starten binnen het droge maaivenster
+    mode: single
+    triggers:
+      - trigger: time_pattern
+        minutes: "/5"
+    conditions:
+      - condition: state
+        entity_id: sensor.eufy_maaiplanning
+        state: Klaar om te maaien
+    actions:
+      - action: script.eufy_gepland_maaien
+
+  - id: eufy_planning_bewaken
+    alias: Eufy - automatische maaibeurt bewaken
+    mode: single
+    triggers:
+      - trigger: time_pattern
+        minutes: "/1"
+      - trigger: state
+        entity_id: switch.example_irrigation_valve
+        to: "on"
+      - trigger: state
+        entity_id: input_boolean.example_irrigation_active
+        to: "on"
+    conditions:
+      - condition: state
+        entity_id: input_boolean.eufy_planning_eigen_sessie
+        state: "on"
+      - condition: template
+        value_template: >-
+          {{ states('lawn_mower.eufy_robomow_e15_mower') in ['mowing','paused'] }}
+    actions:
+      - choose:
+          - conditions: >-
+              {{ as_timestamp(now()) - as_timestamp(states('input_datetime.eufy_laatste_startpoging'), 0)
+                 >= states('input_number.eufy_maximale_sessieduur') | float(90) * 60 }}
+            sequence:
+              - action: input_boolean.turn_off
+                target:
+                  entity_id: input_boolean.eufy_planning_eigen_sessie
+              - action: lawn_mower.dock
+                continue_on_error: true
+                target:
+                  entity_id: lawn_mower.eufy_robomow_e15_mower
+              - action: persistent_notification.create
+                data:
+                  notification_id: eufy_maaisessie_duur
+                  title: Eufy maximale sessieduur bereikt
+                  message: >-
+                    De terugkeer is eenmaal aangevraagd. Controleer de opdrachtbevestiging
+                    en de aankomst bij het laadstation; er volgt geen automatische herhaling.
+          - conditions: >-
+              {{ is_state('lawn_mower.eufy_robomow_e15_mower', 'mowing')
+                 and (not is_state('switch.example_irrigation_valve', 'off')
+                   or not is_state('input_boolean.example_irrigation_active', 'off')
+                   or not is_state('sensor.eufy_maaiomstandigheden', 'Droog volgens regenradar')) }}
+            sequence:
+              - action: input_boolean.turn_off
+                target:
+                  entity_id: input_boolean.eufy_planning_eigen_sessie
+              - action: lawn_mower.pause
+                continue_on_error: true
+                target:
+                  entity_id: lawn_mower.eufy_robomow_e15_mower
+              - action: persistent_notification.create
+                data:
+                  notification_id: eufy_maaisessie_onderbroken
+                  title: Eufy maaibeurt onderbroken
+                  message: >-
+                    Pauzeren is eenmaal aangevraagd: {{ states('sensor.eufy_maaiomstandigheden') }}.
+                    Controleer of de maaier is gestopt. Hervat pas na controle van het gazon.
+                    Er volgt geen automatische hervatting of herhaling.
+
+  - id: eufy_planning_sessie_afgelopen
+    alias: Eufy - automatische sessie afsluiten
+    mode: single
+    triggers:
+      - trigger: state
+        entity_id: lawn_mower.eufy_robomow_e15_mower
+        to: docked
+        for: "00:02:00"
+    actions:
+      - action: input_boolean.turn_off
+        target:
+          entity_id: input_boolean.eufy_planning_eigen_sessie

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py314"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+homeassistant==2026.7.1
+pytest==9.1.1
+requests==2.34.2
+ruff==0.15.20
+tinytuya==1.20.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
-homeassistant==2026.7.1
+homeassistant==2026.7.2
+mypy>=1.17,<2
+pip-audit>=2.9,<3
 pytest==9.1.1
 requests==2.34.2
 ruff==0.15.20

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Eufy Robomow integration."""

--- a/tests/frontend/card.test.mjs
+++ b/tests/frontend/card.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+globalThis.HTMLElement = class {};
+globalThis.customElements = {get:() => true};
+globalThis.window = {};
+const {controls, mapHealth, escapeHTML} = await import('../../custom_components/eufy_robomow/frontend/eufy-mower-card.js');
+const now = Date.parse('2026-09-06T12:00:00Z');
+const mower = (state, options = {}) => ({state, attributes:{operating_mode:'control', supported_features:7, telemetry_updated_at:new Date(now).toISOString(), ...options}});
+test('observe-only and stale status disable physical controls', () => {
+  assert.equal(controls(mower('docked', {operating_mode:'observe_only'}), now).start, false);
+  assert.equal(controls(mower('docked', {telemetry_updated_at:'2026-09-06T11:58:00Z'}), now).start, false);
+  assert.equal(controls(mower('docked'), now).start, true);
+  assert.equal(controls(mower('unavailable'), now).start, false);
+});
+test('pending start cannot repeat, safety pause stays available', () => {
+  assert.equal(controls(mower('docked', {command:{state:'pending'}}), now).start, false);
+  assert.equal(controls(mower('mowing', {command:{state:'pending'}}), now).pause, true);
+  assert.equal(controls(mower('mowing', {supported_features:1}), now).pause, false);
+});
+test('old image is visibly cached even when image entity is available', () => {
+  const image = {state:'2026-09-06T11:55:00Z', attributes:{acquisition_status:'healthy', acquisition_last_success:'2026-09-06T11:55:00Z'}};
+  assert.equal(mapHealth(image, true, now).kind, 'warn');
+  assert.equal(mapHealth(image, false, now).kind, 'good');
+  image.attributes.acquisition_status = 'failed';
+  assert.equal(mapHealth(image, false, now).kind, 'warn');
+});
+test('entity values cannot inject markup', () => {
+  assert.equal(escapeHTML('<img onerror="x">'), '&lt;img onerror=&quot;x&quot;&gt;');
+});

--- a/tests/frontend/card.test.mjs
+++ b/tests/frontend/card.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 globalThis.HTMLElement = class {};
 globalThis.customElements = {get:() => true};
 globalThis.window = {};
-const {controls, mapHealth, escapeHTML} = await import('../../custom_components/eufy_robomow/frontend/eufy-mower-card.js');
+const {controls, mapHealth, escapeHTML, cardView} = await import('../../custom_components/eufy_robomow/frontend/eufy-mower-card.js');
 const now = Date.parse('2026-09-06T12:00:00Z');
 const mower = (state, options = {}) => ({state, attributes:{operating_mode:'control', supported_features:7, telemetry_updated_at:new Date(now).toISOString(), ...options}});
 test('observe-only and stale status disable physical controls', () => {
@@ -26,4 +26,10 @@ test('old image is visibly cached even when image entity is available', () => {
 });
 test('entity values cannot inject markup', () => {
   assert.equal(escapeHTML('<img onerror="x">'), '&lt;img onerror=&quot;x&quot;&gt;');
+});
+test('existing cards retain their combined view and invalid sections are rejected', () => {
+  assert.equal(cardView(), 'all');
+  for (const view of ['overview', 'history', 'planning', 'settings']) assert.equal(cardView(view), view);
+  assert.throws(() => cardView('zone-control'), /paneelweergave/);
+  assert.throws(() => cardView(null), /paneelweergave/);
 });

--- a/tests/map_fixtures.py
+++ b/tests/map_fixtures.py
@@ -1,0 +1,83 @@
+"""Synthetic E15 protobuf fixtures without private lawn geometry."""
+
+from __future__ import annotations
+
+
+def varint(value: int) -> bytes:
+    encoded = bytearray()
+    while True:
+        current = value & 0x7F
+        value >>= 7
+        encoded.append(current | (0x80 if value else 0))
+        if not value:
+            return bytes(encoded)
+
+
+def integer(field: int, value: int) -> bytes:
+    return varint(field << 3) + varint(value)
+
+
+def sint32(value: int) -> int:
+    return (value << 1) ^ (value >> 31)
+
+
+def message(field: int, payload: bytes) -> bytes:
+    return varint((field << 3) | 2) + varint(len(payload)) + payload
+
+
+def point(
+    x: int,
+    y: int,
+    *,
+    x_field: int = 1,
+    y_field: int = 2,
+) -> bytes:
+    encoded = b""
+    if x:
+        encoded += integer(x_field, sint32(x))
+    if y:
+        encoded += integer(y_field, sint32(y))
+    return encoded
+
+
+def map_payload(*, include_embedded_position: bool = True) -> bytes:
+    boundary = b"".join(
+        message(1, point(x, y)) for x, y in ((-20, 0), (100, 0), (100, 80), (0, 80))
+    )
+    restriction = b"".join(
+        message(1, point(x, y)) for x, y in ((20, 20), (30, 20), (30, 30), (20, 30))
+    )
+    pathway = b"".join(message(1, point(x, y)) for x, y in ((-30, 10), (-10, 10)))
+    base_area = b"".join(
+        message(1, point(x, y)) for x, y in ((40, 70), (70, 70), (70, 85), (40, 85))
+    )
+    embedded_position = (
+        message(8, point(9, 10, x_field=2, y_field=3))
+        if include_embedded_position
+        else b""
+    )
+    record = b"".join(
+        (
+            embedded_position,
+            message(10, message(3, boundary)),
+            message(11, restriction),
+            integer(16, 539),
+            message(18, pathway),
+            message(26, integer(1, 1) + message(2, base_area)),
+        )
+    )
+    return message(2, message(1, record))
+
+
+def clean_path_payload() -> bytes:
+    items = (
+        ((0, 0), 0),
+        ((10, 0), 0),
+        ((20, 0), 1),
+        ((30, 0), 1),
+        ((200, 200), 1),
+    )
+    return b"".join(
+        message(7, message(1, point(x, y)) + integer(2, event))
+        for (x, y), event in items
+    )

--- a/tests/test_cloud_codec.py
+++ b/tests/test_cloud_codec.py
@@ -1,0 +1,82 @@
+"""Regression tests for independently testable protocol codecs."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_cloud_module():
+    module_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "eufy_robomow"
+        / "cloud.py"
+    )
+    spec = importlib.util.spec_from_file_location("eufy_robomow_cloud", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cloud = _load_cloud_module()
+
+
+@pytest.mark.parametrize("value", [0, 1, 127, 128, 359, 2**32, 2**64 - 1])
+def test_varint_round_trip(value: int) -> None:
+    encoded = cloud._varint_encode(value)
+
+    decoded, position = cloud._varint_decode(encoded, 0)
+
+    assert decoded == value
+    assert position == len(encoded)
+
+
+def test_varint_decode_rejects_truncated_input() -> None:
+    with pytest.raises(ValueError, match="Truncated"):
+        cloud._varint_decode(b"\x80", 0)
+
+
+def test_varint_decode_rejects_oversized_input() -> None:
+    with pytest.raises(ValueError, match="exceeds 10 bytes"):
+        cloud._varint_decode(b"\x80" * 11, 0)
+
+
+@pytest.mark.parametrize(
+    ("edge_mm", "path_mm", "travel_speed", "blade_speed", "pad_direction"),
+    [
+        (0, 80, "slow", "slow", 0),
+        (70, 100, "normal", "fast", 90),
+        (-150, 120, "fast", "normal", 359),
+    ],
+)
+def test_dp155_round_trip(
+    edge_mm: int,
+    path_mm: int,
+    travel_speed: str,
+    blade_speed: str,
+    pad_direction: int,
+) -> None:
+    blob = cloud._encode_dp155(
+        edge_mm=edge_mm,
+        path_mm=path_mm,
+        travel_speed=travel_speed,
+        blade_speed=blade_speed,
+        pad_direction=pad_direction,
+    )
+
+    assert cloud._decode_dp155(blob) == {
+        "edge_mm": edge_mm,
+        "path_mm": path_mm,
+        "travel_speed": travel_speed,
+        "blade_speed": blade_speed,
+        "pad_direction": pad_direction,
+    }
+
+
+def test_dp155_decode_rejects_invalid_base64() -> None:
+    with pytest.raises(ValueError, match="valid base64"):
+        cloud._decode_dp155("not-base64!")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,108 @@
+"""Physical command acknowledgements must come from post-write local samples."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.eufy_robomow.commands import MowerCommand, command_evidence
+from custom_components.eufy_robomow.coordinator import EufyMowerCoordinator
+
+
+@pytest.mark.parametrize(
+    "action,dps,evidence",
+    [
+        ("start", {"1": True, "2": False, "118": 0}, "mowing_reported"),
+        ("start", {"1": True, "2": False, "118": 50}, None),
+        ("resume", {"1": True, "2": True, "118": 0}, None),
+        ("start", {"1": True}, None),
+        ("pause", {"1": True, "2": True}, "pause_reported"),
+        ("pause", {"1": False, "2": True}, None),
+        ("dock", {"1": False}, "task_inactive"),
+        ("dock", {"1": True, "118": 30}, "returning_reported"),
+    ],
+)
+def test_command_evidence_is_precise(action, dps, evidence):
+    assert command_evidence(action, dps) == evidence
+
+
+def test_cached_and_prewrite_values_cannot_confirm():
+    op = MowerCommand("pause", 4)
+    op.observe(5, {"1": True, "2": True})
+    assert op.state == "sending"
+    op.state = "pending"
+    op.observe(4, {"1": True, "2": True})
+    assert op.state == "pending"
+    op.observe(5, {})
+    assert op.state == "pending"
+    op.observe(5, {"1": True, "2": True})
+    assert op.state == "confirmed"
+
+
+def coordinator():
+    c = object.__new__(EufyMowerCoordinator)
+    c.operating_mode = "control"
+    c.local_generation = 1
+    c.command = None
+    c.async_update_listeners = Mock()
+    c.hass = SimpleNamespace(async_add_executor_job=AsyncMock(return_value={}))
+    c.async_request_refresh = AsyncMock()
+    return c
+
+
+def test_timeout_is_visible_and_never_resends():
+    async def run():
+        c = coordinator()
+        with pytest.raises(HomeAssistantError, match="did not confirm"):
+            await c.async_send_mower_command("start", timeout=0.01)
+        assert c.command.state == "timeout"
+        c.hass.async_add_executor_job.assert_awaited_once()
+
+    asyncio.run(run())
+
+
+def test_refresh_confirms_command():
+    async def run():
+        c = coordinator()
+
+        async def refresh():
+            c.command.observe(2, {"1": True, "2": True})
+
+        c.async_request_refresh = refresh
+        await c.async_send_mower_command("pause", timeout=0.1)
+        assert c.command.evidence == "pause_reported"
+
+    asyncio.run(run())
+
+
+def test_observe_only_never_reaches_transport():
+    async def run():
+        c = coordinator()
+        c.operating_mode = "observe_only"
+        with pytest.raises(HomeAssistantError, match="observe-only"):
+            await c.async_send_mower_command("start")
+        c.hass.async_add_executor_job.assert_not_awaited()
+
+    asyncio.run(run())
+
+
+def test_pause_can_supersede_pending_start():
+    async def run():
+        c = coordinator()
+        task = asyncio.create_task(c.async_send_mower_command("start", timeout=1))
+        await asyncio.sleep(0)
+        old = c.command
+
+        async def refresh():
+            c.command.observe(3, {"1": True, "2": True})
+
+        c.async_request_refresh = refresh
+        await c.async_send_mower_command("pause")
+        with pytest.raises(HomeAssistantError, match="superseded"):
+            await task
+        assert old.state == "superseded"
+        assert c.command.state == "confirmed"
+
+    asyncio.run(run())

--- a/tests/test_control_mode.py
+++ b/tests/test_control_mode.py
@@ -1,0 +1,34 @@
+"""Tests for the physical-control safety boundary."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.eufy_robomow.const import (
+    OPERATING_MODE_CONTROL,
+    OPERATING_MODE_OBSERVE_ONLY,
+)
+from custom_components.eufy_robomow.coordinator import EufyMowerCoordinator
+
+
+def _coordinator_for_mode(operating_mode: str) -> EufyMowerCoordinator:
+    coordinator = object.__new__(EufyMowerCoordinator)
+    coordinator.operating_mode = operating_mode
+    return coordinator
+
+
+def test_observe_only_rejects_writes() -> None:
+    coordinator = _coordinator_for_mode(OPERATING_MODE_OBSERVE_ONLY)
+
+    assert coordinator.control_enabled is False
+    with pytest.raises(HomeAssistantError, match="observe-only mode"):
+        coordinator._require_control_enabled()
+
+
+def test_control_mode_allows_writes() -> None:
+    coordinator = _coordinator_for_mode(OPERATING_MODE_CONTROL)
+
+    assert coordinator.control_enabled is True
+    coordinator._require_control_enabled()

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,95 @@
+"""Tests for live E15 map image behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from custom_components.eufy_robomow.const import DP_TASK_ACTIVE
+from custom_components.eufy_robomow.coordinator import EufyMowerCoordinator
+from custom_components.eufy_robomow.image import EufyRobomowMapImage
+from custom_components.eufy_robomow.map import MapSnapshot, Point
+from custom_components.eufy_robomow.map_source import LoadedMap, MapSource
+
+
+def _snapshot(
+    *,
+    cleaned_paths: tuple[tuple[Point, ...], ...],
+    tracking_position: Point,
+) -> MapSnapshot:
+    return MapSnapshot(
+        map_id=539,
+        boundary=(Point(0, 0), Point(100, 0), Point(100, 100), Point(0, 100)),
+        base_areas=(),
+        no_go_areas=(),
+        pathways=(),
+        cleaned_paths=cleaned_paths,
+        mower_position=Point(5, 50),
+        tracking_position=tracking_position,
+    )
+
+
+class _SequenceMapSource:
+    def __init__(self, snapshots: list[MapSnapshot]) -> None:
+        self._snapshots = snapshots
+        self._index = 0
+        self.streaming_requests: list[bool] = []
+        self.status = SimpleNamespace(
+            state="healthy",
+            last_success=datetime(2026, 7, 27, tzinfo=UTC),
+            last_error=None,
+        )
+
+    async def async_refresh(self, *, streaming: bool = False) -> LoadedMap:
+        self.streaming_requests.append(streaming)
+        snapshot = self._snapshots[self._index]
+        self._index += 1
+        return LoadedMap(
+            snapshot_id=f"snapshot-{self._index}",
+            captured_at=datetime(2026, 7, 27, 8, self._index, tzinfo=UTC),
+            snapshot=snapshot,
+        )
+
+
+def test_map_image_accumulates_live_deltas_and_resets_when_idle(
+    tmp_path: Path,
+) -> None:
+    async def run_test() -> None:
+        first = _snapshot(
+            cleaned_paths=((Point(10, 10), Point(10, 80)),),
+            tracking_position=Point(10, 80),
+        )
+        delta = _snapshot(
+            cleaned_paths=(),
+            tracking_position=Point(20, 80),
+        )
+        source = _SequenceMapSource([first, delta, delta])
+        coordinator = SimpleNamespace(data={DP_TASK_ACTIVE: True})
+        entry = SimpleNamespace(data={"device_id": "synthetic-device"})
+        hass = HomeAssistant(str(tmp_path))
+        entity = EufyRobomowMapImage(
+            hass,
+            cast(EufyMowerCoordinator, coordinator),
+            cast(MapSource, source),
+            cast(ConfigEntry, entry),
+        )
+
+        await entity.async_update()
+        assert b'class="cleaned-path"' in (entity.image() or b"")
+
+        await entity.async_update()
+        assert b'class="cleaned-path"' in (entity.image() or b"")
+
+        coordinator.data[DP_TASK_ACTIVE] = False
+        await entity.async_update()
+        assert b'class="cleaned-path"' not in (entity.image() or b"")
+        assert source.streaming_requests == [True, True, False]
+        await hass.async_stop()
+
+    asyncio.run(run_test())

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import EntityPlatform
 
 from custom_components.eufy_robomow.const import DP_TASK_ACTIVE
 from custom_components.eufy_robomow.coordinator import EufyMowerCoordinator
@@ -90,6 +92,46 @@ def test_map_image_accumulates_live_deltas_and_resets_when_idle(
         await entity.async_update()
         assert b'class="cleaned-path"' not in (entity.image() or b"")
         assert source.streaming_requests == [True, True, False]
+        await hass.async_stop()
+
+    asyncio.run(run_test())
+
+
+def test_home_assistant_poll_updates_map_and_streaming_mode(tmp_path, monkeypatch):
+    """Exercise HA's polling filter, which skips non-polling ImageEntity defaults."""
+
+    async def run_test():
+        snapshot = _snapshot(cleaned_paths=(), tracking_position=Point(20, 80))
+        source = _SequenceMapSource([snapshot, snapshot])
+        coordinator = SimpleNamespace(data={DP_TASK_ACTIVE: True})
+        hass = HomeAssistant(str(tmp_path))
+        entity = EufyRobomowMapImage(
+            hass, coordinator, source, SimpleNamespace(data={"device_id": "synthetic-device"})
+        )
+        entity.hass = hass
+        platform = EntityPlatform(
+            hass=hass,
+            logger=logging.getLogger(__name__),
+            domain="image",
+            platform_name="eufy_robomow",
+            platform=None,
+            scan_interval=timedelta(seconds=2),
+            entity_namespace=None,
+        )
+        platform.entities["image.test_mower"] = entity
+
+        async def update_state(force_refresh=False):
+            assert force_refresh
+            await entity.async_update()
+
+        # State registration is unrelated to polling eligibility; run the real
+        # platform polling path and source/render work, without writing HA state.
+        monkeypatch.setattr(entity, "async_update_ha_state", update_state)
+        await platform._async_update_entity_states()
+        coordinator.data[DP_TASK_ACTIVE] = False
+        await platform._async_update_entity_states()
+        assert source.streaming_requests == [True, False]
+        assert entity.image() is not None
         await hass.async_stop()
 
     asyncio.run(run_test())

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -167,3 +167,23 @@ def test_parse_map_snapshot_rejects_coordinate_outside_sint32() -> None:
 
     with pytest.raises(MapDecodeError, match="sint32"):
         parse_map_snapshot(message(2, message(1, record)), b"", b"")
+
+
+def test_parse_map_snapshot_skips_point_message_without_coordinates() -> None:
+    boundary = b"".join(
+        (
+            message(1, point(10, 0)),
+            message(1, integer(3, 99)),
+            message(1, point(10, 10)),
+            message(1, point(0, 10)),
+        )
+    )
+    record = integer(16, 1) + message(10, message(3, boundary))
+
+    snapshot = parse_map_snapshot(message(2, message(1, record)), b"", b"")
+
+    assert snapshot.boundary == (
+        Point(10, 0),
+        Point(10, 10),
+        Point(0, 10),
+    )

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,169 @@
+"""Tests for the confirmed E15 map decoder."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.eufy_robomow.map import (
+    MapDecodeError,
+    MapSnapshot,
+    Point,
+    merge_live_snapshots,
+    parse_map_snapshot,
+)
+
+from .map_fixtures import (
+    clean_path_payload,
+    integer,
+    map_payload,
+    message,
+    point,
+    varint,
+)
+
+
+def test_parse_map_snapshot_builds_confirmed_geometry() -> None:
+    snapshot = parse_map_snapshot(
+        map_payload(),
+        clean_path_payload(),
+        point(11, 12, x_field=2, y_field=3),
+    )
+
+    assert snapshot.map_id == 539
+    assert snapshot.boundary == (
+        Point(-20, 0),
+        Point(100, 0),
+        Point(100, 80),
+        Point(0, 80),
+    )
+    assert len(snapshot.base_areas) == 1
+    assert len(snapshot.no_go_areas) == 1
+    assert len(snapshot.pathways) == 1
+    assert tuple(map(len, snapshot.cleaned_paths)) == (2,)
+    assert snapshot.mower_position == Point(9, 10)
+    assert snapshot.tracking_position == Point(200, 200)
+
+
+def test_parse_map_snapshot_falls_back_to_navigation_position() -> None:
+    snapshot = parse_map_snapshot(
+        map_payload(include_embedded_position=False),
+        clean_path_payload(),
+        point(11, 12, x_field=2, y_field=3),
+    )
+
+    assert snapshot.mower_position == Point(11, 12)
+
+
+def test_parse_map_snapshot_keeps_sparse_straight_mowing_pass_connected() -> None:
+    clean_path = b"".join(
+        message(7, message(1, point(x, y))) for x, y in ((100, -5000), (100, 1000))
+    )
+
+    snapshot = parse_map_snapshot(
+        map_payload(),
+        clean_path,
+        point(11, 12, x_field=2, y_field=3),
+    )
+
+    assert snapshot.cleaned_paths == (
+        (
+            Point(100, -5000),
+            Point(100, 1000),
+        ),
+    )
+    assert snapshot.tracking_position == Point(100, 1000)
+
+
+def test_merge_live_snapshots_accumulates_unique_coverage_and_latest_position() -> None:
+    shared = Point(20, 20)
+    previous = MapSnapshot(
+        map_id=539,
+        boundary=(Point(0, 0), Point(100, 0), Point(0, 100)),
+        base_areas=(),
+        no_go_areas=(),
+        pathways=(),
+        cleaned_paths=((Point(10, 10), shared),),
+        mower_position=Point(5, 5),
+        tracking_position=shared,
+    )
+    current = MapSnapshot(
+        map_id=539,
+        boundary=previous.boundary,
+        base_areas=(),
+        no_go_areas=(),
+        pathways=(),
+        cleaned_paths=(
+            (shared, Point(10, 10)),
+            (shared, Point(30, 30)),
+        ),
+        mower_position=Point(5, 5),
+        tracking_position=Point(30, 30),
+    )
+
+    merged = merge_live_snapshots(previous, current)
+
+    assert merged.cleaned_paths == (
+        (
+            Point(10, 10),
+            shared,
+            Point(30, 30),
+        ),
+    )
+    assert merged.tracking_position == Point(30, 30)
+
+
+def test_merge_live_snapshots_resets_when_map_changes() -> None:
+    previous = MapSnapshot(
+        map_id=539,
+        boundary=(Point(0, 0), Point(100, 0), Point(0, 100)),
+        base_areas=(),
+        no_go_areas=(),
+        pathways=(),
+        cleaned_paths=((Point(10, 10), Point(20, 20)),),
+        mower_position=None,
+    )
+    current = MapSnapshot(
+        map_id=540,
+        boundary=previous.boundary,
+        base_areas=(),
+        no_go_areas=(),
+        pathways=(),
+        cleaned_paths=(),
+        mower_position=None,
+    )
+
+    assert merge_live_snapshots(previous, current) is current
+
+
+def test_parse_map_snapshot_rejects_missing_boundary() -> None:
+    payload = message(2, message(1, integer(16, 1)))
+
+    with pytest.raises(MapDecodeError, match="boundary"):
+        parse_map_snapshot(payload, b"", b"")
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        (b"\x00", "field number 0"),
+        (b"\x08", "Truncated"),
+        (b"\x12\x04abc", "exceeds payload"),
+        (varint((1 << 3) | 5) + b"\x00\x00\x00\x00", "wire type 5"),
+        (b"\x08" + (b"\x80" * 10), "exceeds 10 bytes"),
+    ],
+)
+def test_parse_map_snapshot_rejects_malformed_protobuf(
+    payload: bytes,
+    error: str,
+) -> None:
+    with pytest.raises(MapDecodeError, match=error):
+        parse_map_snapshot(payload, b"", b"")
+
+
+def test_parse_map_snapshot_rejects_coordinate_outside_sint32() -> None:
+    oversized_coordinate = integer(1, 0x1_0000_0000)
+    boundary = b"".join(message(1, oversized_coordinate) for _ in range(3))
+    record = integer(16, 1) + message(10, message(3, boundary))
+
+    with pytest.raises(MapDecodeError, match="sint32"):
+        parse_map_snapshot(message(2, message(1, record)), b"", b"")

--- a/tests/test_map_renderer.py
+++ b/tests/test_map_renderer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from custom_components.eufy_robomow.map import MapSnapshot, Point
 from custom_components.eufy_robomow.map_renderer import (
     MAP_CONTENT_TYPE,
@@ -55,7 +57,7 @@ def test_render_map_svg_is_deterministic_and_script_free() -> None:
     assert b'class="boundary"' in rendered
     assert b'class="base-area"' in rendered
     assert b'class="no-go-area"' in rendered
-    assert rendered.count(b'class="pathway"') == 1
+    assert rendered.count(b'class="pathway"') == 2
     assert b'class="mower-marker"' in rendered
 
 
@@ -74,3 +76,27 @@ def test_render_map_svg_can_show_current_cleaned_path() -> None:
     assert b'class="charging-station"' in rendered
     assert b"scale(.75)" in rendered
     assert b'class="mower-lightning"' not in rendered
+
+
+def test_render_map_svg_keeps_offset_markers_inside_canvas() -> None:
+    snapshot = MapSnapshot(
+        map_id=539,
+        boundary=(Point(0, 0), Point(100, 0), Point(100, 100), Point(0, 100)),
+        base_areas=(),
+        no_go_areas=(),
+        pathways=(),
+        cleaned_paths=((Point(0, 0), Point(100, 100)),),
+        mower_position=Point(1000, 1000),
+        tracking_position=Point(0, 0),
+    )
+
+    rendered = render_map_svg(snapshot, include_cleaned_paths=True)
+    positions = re.findall(
+        rb'class="(?:charging-station|mower-marker)" '
+        rb'transform="translate\(([\d.]+) ([\d.]+)\)',
+        rendered,
+    )
+
+    assert len(positions) == 2
+    assert all(20 <= float(x) <= 700 for x, _ in positions)
+    assert all(28 <= float(y) <= 872 for _, y in positions)

--- a/tests/test_map_renderer.py
+++ b/tests/test_map_renderer.py
@@ -1,0 +1,76 @@
+"""Tests for deterministic, script-free E15 map rendering."""
+
+from __future__ import annotations
+
+from custom_components.eufy_robomow.map import MapSnapshot, Point
+from custom_components.eufy_robomow.map_renderer import (
+    MAP_CONTENT_TYPE,
+    render_map_svg,
+)
+
+
+def _snapshot() -> MapSnapshot:
+    return MapSnapshot(
+        map_id=539,
+        boundary=(
+            Point(0, 0),
+            Point(100, 0),
+            Point(100, 100),
+            Point(0, 100),
+        ),
+        base_areas=(
+            (
+                Point(40, 90),
+                Point(70, 90),
+                Point(70, 110),
+                Point(40, 110),
+            ),
+        ),
+        no_go_areas=(
+            (
+                Point(20, 20),
+                Point(30, 20),
+                Point(30, 30),
+                Point(20, 30),
+            ),
+        ),
+        pathways=(
+            (Point(-20, 50), Point(10, 50)),
+            (Point(40, 40), Point(60, 60)),
+        ),
+        cleaned_paths=((Point(10, 10), Point(20, 10)),),
+        mower_position=Point(45, 50),
+        tracking_position=Point(20, 10),
+    )
+
+
+def test_render_map_svg_is_deterministic_and_script_free() -> None:
+    rendered = render_map_svg(_snapshot())
+
+    assert rendered == render_map_svg(_snapshot())
+    assert MAP_CONTENT_TYPE == "image/svg+xml"
+    assert rendered.startswith(b'<svg xmlns="http://www.w3.org/2000/svg"')
+    assert b"<title>Eufy mower map 539</title>" in rendered
+    assert b"<script" not in rendered.lower()
+    assert b'class="boundary"' in rendered
+    assert b'class="base-area"' in rendered
+    assert b'class="no-go-area"' in rendered
+    assert rendered.count(b'class="pathway"') == 1
+    assert b'class="mower-marker"' in rendered
+
+
+def test_render_map_svg_hides_historical_cleaned_path_by_default() -> None:
+    assert b'class="cleaned-path"' not in render_map_svg(_snapshot())
+
+
+def test_render_map_svg_can_show_current_cleaned_path() -> None:
+    rendered = render_map_svg(
+        _snapshot(),
+        include_cleaned_paths=True,
+    )
+
+    assert b'class="cleaned-area" clip-path="url(#mowing-boundary-clip)"' in rendered
+    assert b'class="cleaned-path"' in rendered
+    assert b'class="charging-station"' in rendered
+    assert b"scale(.75)" in rendered
+    assert b'class="mower-lightning"' not in rendered

--- a/tests/test_map_source.py
+++ b/tests/test_map_source.py
@@ -8,7 +8,9 @@ import hashlib
 from io import BytesIO
 import json
 from pathlib import Path
+from stat import S_IMODE
 from typing import cast
+from unittest.mock import patch
 from zipfile import ZIP_STORED, ZipFile
 
 import aiohttp
@@ -21,6 +23,7 @@ from custom_components.eufy_robomow.map_source import (
     MapSource,
     MapSourceError,
     MapSourceSettings,
+    _MapFetch,
     decode_map_bundle,
     read_cached_bundle,
     write_cached_bundle,
@@ -57,6 +60,7 @@ def _snapshot_digest(payloads: dict[str, bytes]) -> str:
 def _bundle(
     *,
     device_id: str = _DEVICE_ID,
+    captured_at: int = 1_700_000_000,
     mutate_manifest: object | None = None,
     extra_member: bool = False,
 ) -> bytes:
@@ -64,7 +68,7 @@ def _bundle(
     manifest: object = {
         "schema_version": 1,
         "device_id": device_id,
-        "captured_at": 1_700_000_000,
+        "captured_at": captured_at,
         "snapshot_id": _snapshot_digest(payloads),
         "files": {
             filename: {
@@ -115,13 +119,19 @@ def test_decode_map_bundle_rejects_invalid_manifest() -> None:
 
 
 def test_cache_round_trip_is_single_atomic_file(tmp_path: Path) -> None:
-    cache_file = tmp_path / "private" / "latest.mapbundle"
+    cache_root = tmp_path / "eufy_robomow_maps"
+    cache_root.mkdir(mode=0o777)
+    cache_root.chmod(0o777)
+    cache_file = cache_root / "entry" / "latest.mapbundle"
     encoded = _bundle()
 
-    write_cached_bundle(cache_file, encoded)
+    write_cached_bundle(cache_file, encoded, cache_root)
 
     assert read_cached_bundle(cache_file) == encoded
     assert list(cache_file.parent.iterdir()) == [cache_file]
+    assert S_IMODE(cache_root.stat().st_mode) == 0o700
+    assert S_IMODE(cache_file.parent.stat().st_mode) == 0o700
+    assert S_IMODE(cache_file.stat().st_mode) == 0o600
 
 
 def test_map_source_settings_are_optional() -> None:
@@ -176,16 +186,23 @@ class _FakeHass:
 
 
 class _StaticMapSource(MapSource):
-    def __init__(self, *args, response: bytes | BaseException, **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        response: bytes | BaseException,
+        response_etag: str | None = None,
+        **kwargs,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self._response = response
+        self._response_etag = response_etag
         self.streaming_requests: list[bool] = []
 
-    async def _async_fetch(self, *, streaming: bool) -> bytes:
+    async def _async_fetch(self, *, streaming: bool) -> _MapFetch:
         self.streaming_requests.append(streaming)
         if isinstance(self._response, BaseException):
             raise self._response
-        return self._response
+        return _MapFetch(self._response, self._response_etag)
 
 
 def _settings() -> MapSourceSettings:
@@ -233,6 +250,45 @@ def test_map_source_throttles_idle_and_switches_to_streaming(tmp_path: Path) -> 
     assert source.streaming_requests == [False, True]
 
 
+def test_map_source_backs_off_before_first_success(tmp_path: Path) -> None:
+    source = _StaticMapSource(
+        cast(HomeAssistant, _FakeHass()),
+        settings=_settings(),
+        device_id=_DEVICE_ID,
+        cache_file=tmp_path / "latest.mapbundle",
+        response=aiohttp.ClientConnectionError("synthetic failure"),
+    )
+
+    with pytest.raises(MapSourceError, match="No valid"):
+        asyncio.run(source.async_refresh(streaming=True))
+    with pytest.raises(MapSourceError, match="transport failed"):
+        asyncio.run(source.async_refresh(streaming=True))
+
+    assert source.streaming_requests == [True]
+
+
+def test_map_source_rejects_older_snapshot(tmp_path: Path) -> None:
+    source = _StaticMapSource(
+        cast(HomeAssistant, _FakeHass()),
+        settings=_settings(),
+        device_id=_DEVICE_ID,
+        cache_file=tmp_path / "latest.mapbundle",
+        response=_bundle(captured_at=1_700_000_001),
+        response_etag='"new"',
+    )
+
+    current = asyncio.run(source.async_refresh())
+    source._response = _bundle(captured_at=1_700_000_000)
+    source._response_etag = '"old"'
+    retained = asyncio.run(source.async_refresh(streaming=True))
+
+    assert retained is current
+    assert retained.captured_at == datetime.fromtimestamp(1_700_000_001, tz=UTC)
+    assert source.status.state == "stale"
+    assert source.status.last_error == "Map source returned an older snapshot"
+    assert source._etags == {False: '"new"'}
+
+
 def test_map_source_retains_cached_map_after_transport_failure(
     tmp_path: Path,
 ) -> None:
@@ -251,3 +307,73 @@ def test_map_source_retains_cached_map_after_transport_failure(
     assert loaded.snapshot.map_id == 539
     assert source.status.state == "stale"
     assert source.status.last_error == "Map source transport failed"
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status: int,
+        body: bytes = b"",
+        etag: str | None = None,
+    ) -> None:
+        self.status = status
+        self.headers = {
+            "Content-Type": MAP_BUNDLE_CONTENT_TYPE,
+            **({"ETag": etag} if etag is not None else {}),
+        }
+        self.content_length = len(body)
+        self.content = self
+        self._body = body
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+    async def read(self, size: int) -> bytes:
+        return self._body
+
+
+class _FakeSession:
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = responses
+        self.request_headers: list[dict[str, str]] = []
+
+    def get(self, url: str, **kwargs: object) -> _FakeResponse:
+        headers = cast(dict[str, str], kwargs["headers"])
+        self.request_headers.append(dict(headers))
+        return self._responses.pop(0)
+
+
+def test_map_source_tracks_etags_per_mode(tmp_path: Path) -> None:
+    session = _FakeSession(
+        [
+            _FakeResponse(status=200, body=_bundle(), etag='"idle"'),
+            _FakeResponse(status=200, body=_bundle(), etag='"stream"'),
+            _FakeResponse(status=304),
+            _FakeResponse(status=304),
+        ]
+    )
+    source = MapSource(
+        cast(HomeAssistant, _FakeHass()),
+        settings=_settings(),
+        device_id=_DEVICE_ID,
+        cache_file=tmp_path / "latest.mapbundle",
+    )
+
+    with patch(
+        "custom_components.eufy_robomow.map_source.async_get_clientsession",
+        return_value=session,
+    ):
+        idle = asyncio.run(source._async_fetch(streaming=False))
+        stream = asyncio.run(source._async_fetch(streaming=True))
+        source._etags[False] = idle.etag or ""
+        source._etags[True] = stream.etag or ""
+        asyncio.run(source._async_fetch(streaming=False))
+        asyncio.run(source._async_fetch(streaming=True))
+
+    assert [
+        headers.get("If-None-Match") for headers in session.request_headers
+    ] == [None, None, '"idle"', '"stream"']

--- a/tests/test_map_source.py
+++ b/tests/test_map_source.py
@@ -1,0 +1,253 @@
+"""Tests for the strict map bundle and source configuration boundary."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+import hashlib
+from io import BytesIO
+import json
+from pathlib import Path
+from typing import cast
+from zipfile import ZIP_STORED, ZipFile
+
+import aiohttp
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.eufy_robomow.map_source import (
+    MAP_BUNDLE_CONTENT_TYPE,
+    MapSource,
+    MapSourceError,
+    MapSourceSettings,
+    decode_map_bundle,
+    read_cached_bundle,
+    write_cached_bundle,
+)
+
+from .map_fixtures import clean_path_payload, map_payload, point
+
+_DEVICE_ID = "synthetic-device"
+_FILENAMES = (
+    "map.bin.stream",
+    "cleanPath.bin.stream",
+    "navPath.bin.stream",
+)
+
+
+def _payloads() -> dict[str, bytes]:
+    return {
+        "map.bin.stream": map_payload(),
+        "cleanPath.bin.stream": clean_path_payload(),
+        "navPath.bin.stream": point(11, 12, x_field=2, y_field=3),
+    }
+
+
+def _snapshot_digest(payloads: dict[str, bytes]) -> str:
+    digest = hashlib.sha256()
+    for filename in _FILENAMES:
+        payload = payloads[filename]
+        digest.update(filename.encode("ascii"))
+        digest.update(len(payload).to_bytes(8, byteorder="big"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def _bundle(
+    *,
+    device_id: str = _DEVICE_ID,
+    mutate_manifest: object | None = None,
+    extra_member: bool = False,
+) -> bytes:
+    payloads = _payloads()
+    manifest: object = {
+        "schema_version": 1,
+        "device_id": device_id,
+        "captured_at": 1_700_000_000,
+        "snapshot_id": _snapshot_digest(payloads),
+        "files": {
+            filename: {
+                "size": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+            }
+            for filename, payload in payloads.items()
+        },
+    }
+    if mutate_manifest is not None:
+        manifest = mutate_manifest
+
+    output = BytesIO()
+    with ZipFile(output, mode="w", compression=ZIP_STORED) as archive:
+        archive.writestr(
+            "manifest.json",
+            json.dumps(manifest, separators=(",", ":")),
+        )
+        for filename, payload in payloads.items():
+            archive.writestr(filename, payload)
+        if extra_member:
+            archive.writestr("../private", b"not allowed")
+    return output.getvalue()
+
+
+def test_decode_map_bundle_returns_typed_snapshot() -> None:
+    loaded = decode_map_bundle(_bundle(), _DEVICE_ID)
+
+    assert loaded.captured_at == datetime.fromtimestamp(1_700_000_000, tz=UTC)
+    assert loaded.snapshot.map_id == 539
+    assert len(loaded.snapshot.boundary) == 4
+    assert MAP_BUNDLE_CONTENT_TYPE == "application/vnd.eufy-robomow-map+zip"
+
+
+def test_decode_map_bundle_rejects_other_device() -> None:
+    with pytest.raises(MapSourceError, match="different device"):
+        decode_map_bundle(_bundle(), "other-device")
+
+
+def test_decode_map_bundle_rejects_unexpected_archive_path() -> None:
+    with pytest.raises(MapSourceError, match="unexpected"):
+        decode_map_bundle(_bundle(extra_member=True), _DEVICE_ID)
+
+
+def test_decode_map_bundle_rejects_invalid_manifest() -> None:
+    with pytest.raises(MapSourceError, match="manifest"):
+        decode_map_bundle(_bundle(mutate_manifest=["not", "an", "object"]), _DEVICE_ID)
+
+
+def test_cache_round_trip_is_single_atomic_file(tmp_path: Path) -> None:
+    cache_file = tmp_path / "private" / "latest.mapbundle"
+    encoded = _bundle()
+
+    write_cached_bundle(cache_file, encoded)
+
+    assert read_cached_bundle(cache_file) == encoded
+    assert list(cache_file.parent.iterdir()) == [cache_file]
+
+
+def test_map_source_settings_are_optional() -> None:
+    assert (
+        MapSourceSettings.from_values(
+            base_url="",
+            certificate_fingerprint="",
+            local_key="0123456789abcdef",
+        )
+        is None
+    )
+
+
+def test_map_source_settings_derive_authentication() -> None:
+    settings = MapSourceSettings.from_values(
+        base_url="https://map.example.test/",
+        certificate_fingerprint="AA:" * 31 + "AA",
+        local_key="0123456789abcdef",
+    )
+
+    assert settings is not None
+    assert settings.base_url == "https://map.example.test"
+    assert len(settings.access_token) == 64
+    assert settings.certificate_fingerprint == bytes.fromhex("aa" * 32)
+
+
+@pytest.mark.parametrize(
+    ("url", "fingerprint"),
+    [
+        ("http://map.example.test", ""),
+        ("https://user:secret@map.example.test", ""),
+        ("https://map.example.test?device=one", ""),
+        ("", "aa" * 32),
+        ("https://map.example.test", "invalid"),
+    ],
+)
+def test_map_source_settings_reject_unsafe_values(
+    url: str,
+    fingerprint: str,
+) -> None:
+    with pytest.raises(MapSourceError):
+        MapSourceSettings.from_values(
+            base_url=url,
+            certificate_fingerprint=fingerprint,
+            local_key="0123456789abcdef",
+        )
+
+
+class _FakeHass:
+    async def async_add_executor_job(self, target, *args):
+        return target(*args)
+
+
+class _StaticMapSource(MapSource):
+    def __init__(self, *args, response: bytes | BaseException, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._response = response
+        self.streaming_requests: list[bool] = []
+
+    async def _async_fetch(self, *, streaming: bool) -> bytes:
+        self.streaming_requests.append(streaming)
+        if isinstance(self._response, BaseException):
+            raise self._response
+        return self._response
+
+
+def _settings() -> MapSourceSettings:
+    settings = MapSourceSettings.from_values(
+        base_url="https://map.example.test",
+        certificate_fingerprint="",
+        local_key="0123456789abcdef",
+    )
+    assert settings is not None
+    return settings
+
+
+def test_map_source_publishes_successful_bundle(tmp_path: Path) -> None:
+    cache_file = tmp_path / "latest.mapbundle"
+    encoded = _bundle()
+    source = _StaticMapSource(
+        cast(HomeAssistant, _FakeHass()),
+        settings=_settings(),
+        device_id=_DEVICE_ID,
+        cache_file=cache_file,
+        response=encoded,
+    )
+
+    loaded = asyncio.run(source.async_refresh())
+
+    assert loaded.snapshot.map_id == 539
+    assert source.status.state == "healthy"
+    assert read_cached_bundle(cache_file) == encoded
+
+
+def test_map_source_throttles_idle_and_switches_to_streaming(tmp_path: Path) -> None:
+    source = _StaticMapSource(
+        cast(HomeAssistant, _FakeHass()),
+        settings=_settings(),
+        device_id=_DEVICE_ID,
+        cache_file=tmp_path / "latest.mapbundle",
+        response=_bundle(),
+    )
+
+    asyncio.run(source.async_refresh())
+    asyncio.run(source.async_refresh())
+    asyncio.run(source.async_refresh(streaming=True))
+    asyncio.run(source.async_refresh(streaming=True))
+
+    assert source.streaming_requests == [False, True]
+
+
+def test_map_source_retains_cached_map_after_transport_failure(
+    tmp_path: Path,
+) -> None:
+    cache_file = tmp_path / "latest.mapbundle"
+    write_cached_bundle(cache_file, _bundle())
+    source = _StaticMapSource(
+        cast(HomeAssistant, _FakeHass()),
+        settings=_settings(),
+        device_id=_DEVICE_ID,
+        cache_file=cache_file,
+        response=aiohttp.ClientConnectionError("synthetic failure"),
+    )
+
+    loaded = asyncio.run(source.async_refresh())
+
+    assert loaded.snapshot.map_id == 539
+    assert source.status.state == "stale"
+    assert source.status.last_error == "Map source transport failed"

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,92 @@
+"""Regression tests for Eufy Robomow integration options."""
+
+from __future__ import annotations
+
+import asyncio
+from types import MappingProxyType
+from unittest.mock import patch
+
+from homeassistant.config_entries import ConfigEntries, ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from custom_components.eufy_robomow import async_setup_entry
+from custom_components.eufy_robomow.config_flow import EufyRobomowOptionsFlow
+from custom_components.eufy_robomow.const import (
+    CONF_DEVICE_ID,
+    CONF_LOCAL_KEY,
+    CONF_MAP_CERTIFICATE_FINGERPRINT,
+    CONF_MAP_SOURCE_URL,
+    CONF_OPERATING_MODE,
+    DOMAIN,
+    OPERATING_MODE_CONTROL,
+)
+
+
+class _FakeCoordinator:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    async def async_config_entry_first_refresh(self) -> None:
+        pass
+
+
+def test_options_flow_saves_and_schedules_automatic_reload(tmp_path) -> None:
+    async def run_test() -> None:
+        hass = HomeAssistant(str(tmp_path))
+        hass.config_entries = ConfigEntries(hass, {})
+        entry = ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain=DOMAIN,
+            title="Synthetic mower",
+            data={
+                CONF_HOST: "127.0.0.1",
+                CONF_DEVICE_ID: "synthetic-device",
+                CONF_LOCAL_KEY: "0123456789abcdef",
+            },
+            options={},
+            source="user",
+            unique_id="synthetic-device",
+            discovery_keys=MappingProxyType({}),
+            subentries_data=(),
+        )
+        hass.config_entries._entries[entry.entry_id] = entry
+
+        async def async_forward_entry_setups(*args: object) -> None:
+            pass
+
+        with (
+            patch(
+                "custom_components.eufy_robomow.EufyMowerCoordinator",
+                _FakeCoordinator,
+            ),
+            patch.object(
+                hass.config_entries,
+                "async_forward_entry_setups",
+                async_forward_entry_setups,
+            ),
+        ):
+            await async_setup_entry(hass, entry)
+
+        assert not entry.update_listeners
+
+        flow = EufyRobomowOptionsFlow()
+        flow.hass = hass
+        flow.handler = entry.entry_id
+        result = await flow.async_step_init(
+            {
+                CONF_OPERATING_MODE: OPERATING_MODE_CONTROL,
+                CONF_MAP_SOURCE_URL: "",
+                CONF_MAP_CERTIFICATE_FINGERPRINT: "",
+            }
+        )
+
+        with patch.object(hass.config_entries, "async_schedule_reload") as reload_entry:
+            await hass.config_entries.options.async_finish_flow(flow, result)
+
+        assert entry.options[CONF_OPERATING_MODE] == OPERATING_MODE_CONTROL
+        reload_entry.assert_called_once_with(entry.entry_id)
+        await hass.async_stop()
+
+    asyncio.run(run_test())

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,172 @@
+"""Render the actual installed planning templates against HA state scenarios."""
+
+import asyncio
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+import yaml
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.template import Template
+from homeassistant.util import dt as dt_util
+
+PACKAGE = yaml.safe_load(
+    (Path(__file__).parents[1] / "examples/eufy_mower_planning.yaml").read_text()
+)
+CONDITIONS = PACKAGE["template"][0]["sensor"][0]["state"]
+PLANNING = PACKAGE["template"][0]["sensor"][1]["state"]
+
+
+async def render_scenario(tmp_path, overrides=None):
+    hass = HomeAssistant(str(tmp_path))
+    now = dt_util.utcnow()
+    radar = {"success": True, "start": now.timestamp() - 60, "delta": 300, "precip": [0] * 25}
+    states = {
+        "input_boolean.eufy_planning_ingesteld": ("on", {}),
+        "switch.example_irrigation_valve": ("off", {}),
+        "input_boolean.example_irrigation_active": ("off", {}),
+        "input_boolean.example_irrigation_planned": ("off", {}),
+        "sensor.example_buienalarm_rain_data": ("0", {"data": radar}),
+        "input_number.eufy_maximale_sessieduur": ("90", {}),
+        "input_boolean.eufy_automatisch_maaien": ("on", {}),
+        "input_select.eufy_maaidagen": ("Dagelijks", {}),
+        "input_datetime.eufy_maaivenster_start": ("00:00:00", {}),
+        "input_datetime.eufy_maaivenster_einde": ("23:59:59", {}),
+        "input_datetime.eufy_laatste_natte_waarneming": (
+            (now - timedelta(hours=2)).isoformat(),
+            {},
+        ),
+        "input_datetime.eufy_laatste_startpoging": ((now - timedelta(days=1)).isoformat(), {}),
+        "sun.sun": ("above_horizon", {"next_setting": (now + timedelta(hours=5)).isoformat()}),
+        "lawn_mower.eufy_robomow_e15_mower": (
+            "docked",
+            {"telemetry_updated_at": now.isoformat(), "operating_mode": "control"},
+        ),
+        "sensor.eufy_robomow_e15_battery": ("100", {}),
+        "input_number.eufy_minimale_startbatterij": ("80", {}),
+        "input_number.eufy_droogtijd_minuten": ("60", {}),
+        "switch.eufy_robomow_e15_stop_on_rain_detection": ("on", {}),
+        "switch.eufy_robomow_e15_child_protection": ("on", {}),
+    }
+    if overrides:
+        states.update(overrides(now, radar))
+    for entity_id, (state, attrs) in states.items():
+        hass.states.async_set(entity_id, state, attrs)
+    conditions = Template(CONDITIONS, hass).async_render()
+    hass.states.async_set("sensor.eufy_maaiomstandigheden", conditions)
+    planning = Template(PLANNING, hass).async_render()
+    await hass.async_stop()
+    return conditions, planning
+
+
+def test_dry_conditions_allow_one_start(tmp_path):
+    assert asyncio.run(render_scenario(tmp_path)) == (
+        "Droog volgens regenradar",
+        "Klaar om te maaien",
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides,expected",
+    [
+        (
+            lambda n, r: {"input_boolean.eufy_automatisch_maaien": ("off", {})},
+            "Automatisch maaien staat uit",
+        ),
+        (
+            lambda n, r: {"switch.example_irrigation_valve": ("unavailable", {})},
+            "Beregening actief of klepstatus onbekend",
+        ),
+        (
+            lambda n, r: {
+                "sensor.example_buienalarm_rain_data": (
+                    "0",
+                    {"data": {**r, "start": n.timestamp() - 1800}},
+                )
+            },
+            "Regenverwachting ontbreekt of is verouderd",
+        ),
+        (
+            lambda n, r: {
+                "sensor.example_buienalarm_rain_data": ("0", {"data": {**r, "precip": [0] * 5}})
+            },
+            "Regenverwachting dekt de hele maaisessie niet",
+        ),
+        (
+            lambda n, r: {
+                "sensor.example_buienalarm_rain_data": (
+                    "0",
+                    {"data": {**r, "precip": [0] * 5 + [1] + [0] * 19}},
+                )
+            },
+            "Regen gemeld of verwacht",
+        ),
+        (
+            lambda n, r: {"input_datetime.eufy_laatste_startpoging": (n.isoformat(), {})},
+            "Vandaag al een startpoging gedaan",
+        ),
+        (
+            lambda n, r: {"input_datetime.eufy_laatste_natte_waarneming": (n.isoformat(), {})},
+            "Wacht op droogtijd na regen, beregening of herstart",
+        ),
+        (
+            lambda n, r: {
+                "lawn_mower.eufy_robomow_e15_mower": (
+                    "docked",
+                    {
+                        "telemetry_updated_at": (n - timedelta(minutes=2)).isoformat(),
+                        "operating_mode": "control",
+                    },
+                )
+            },
+            "Maaierstatus ontbreekt of is verouderd",
+        ),
+        (
+            lambda n, r: {
+                "input_boolean.example_irrigation_planned": ("on", {}),
+                "input_datetime.example_irrigation_start": (
+                    (n + timedelta(minutes=30)).isoformat(),
+                    {},
+                ),
+            },
+            "Beregening gepland binnen de maaisessie",
+        ),
+        (
+            lambda n, r: {"switch.eufy_robomow_e15_child_protection": ("off", {})},
+            "Regenstop of kinderbeveiliging niet bevestigd",
+        ),
+    ],
+)
+def test_unsafe_or_ambiguous_inputs_block_start(tmp_path, overrides, expected):
+    assert asyncio.run(render_scenario(tmp_path, overrides))[1] == expected
+
+
+def test_actual_script_cannot_start_when_automatic_mode_is_off(tmp_path):
+    """Execute the real script in isolated HA with fake services and no device."""
+    from homeassistant.core import Context
+    from homeassistant.helpers.script import Script
+
+    async def run():
+        hass = HomeAssistant(str(tmp_path))
+        calls = []
+
+        async def record(call):
+            calls.append(call)
+
+        for domain, service in (
+            ("lawn_mower", "start_mowing"),
+            ("input_datetime", "set_datetime"),
+            ("input_boolean", "turn_on"),
+        ):
+            hass.services.async_register(domain, service, record)
+        hass.states.async_set("input_boolean.eufy_automatisch_maaien", "off")
+        # Even an outdated ready sensor must not bypass the explicit off guard.
+        hass.states.async_set("sensor.eufy_maaiplanning", "Klaar om te maaien")
+        script = Script(
+            hass, PACKAGE["script"]["eufy_gepland_maaien"]["sequence"], "Mower guard test", "test"
+        )
+        await script.async_run(context=Context())
+        assert calls == []
+        await hass.async_stop()
+
+    asyncio.run(run())

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,72 @@
+"""Session boundaries, interrupted observation, stale telemetry and persistence."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.eufy_robomow.sessions import SessionHistory, SessionStore
+
+NOW = datetime(2026, 9, 6, 10, tzinfo=UTC)
+
+
+def test_pause_and_missing_task_flag_do_not_end_session():
+    h = SessionHistory()
+    h.observe({"1": False}, NOW)
+    h.observe({"1": True, "2": False, "118": 0}, NOW + timedelta(seconds=10))
+    h.observe({"1": True, "2": True}, NOW + timedelta(seconds=20))
+    h.observe({}, NOW + timedelta(seconds=30))
+    assert h.current is not None
+    assert h.current["pause_count"] == 1
+    assert not h.recent
+    h.observe({"1": False}, NOW + timedelta(seconds=40))
+    assert h.current is None
+    assert h.recent[0]["mowing_seconds"] == 10
+    assert h.recent[0]["observation_gap"] is True
+    assert h.recent[0]["end_observed"] is False
+
+
+def test_long_gap_does_not_count_as_mowing():
+    h = SessionHistory()
+    h.observe({"1": True, "2": False, "118": 0}, NOW)
+    h.observe({"1": True, "2": False, "118": 0}, NOW + timedelta(hours=1))
+    assert h.current["mowing_seconds"] == 0
+    assert h.current["unknown_seconds"] == 3600
+    assert h.current["start_observed"] is False
+
+
+def test_stale_session_blob_is_not_a_new_session_measurement():
+    h = SessionHistory()
+    old = "EAoYBigK"  # total=10, covered=6, distance=10; synthetic
+    h.observe({"1": False, "113": old}, NOW)
+    h.observe({"1": True, "2": False, "118": 0, "113": old}, NOW + timedelta(seconds=10))
+    assert h.current["progress"] is None
+    h.observe({"1": True, "2": False, "118": 0, "113": "EAoYBygL"}, NOW + timedelta(seconds=20))
+    assert h.current["progress"] == 70
+    assert h.current["distance_m"] == 11
+
+
+def test_restart_retains_history_without_inventing_continuity(tmp_path):
+    async def run():
+        hass = HomeAssistant(str(tmp_path))
+        store = SessionStore(hass, "synthetic-entry")
+        store.history.observe({"1": True, "2": False, "118": 0}, NOW)
+        await store.async_save()
+        restored = SessionStore(hass, "synthetic-entry")
+        await restored.async_load()
+        restored.history.observe({"1": False}, NOW + timedelta(hours=1))
+        assert len(restored.history.recent) == 1
+        assert restored.history.recent[0]["mowing_seconds"] == 0
+        assert restored.history.recent[0]["end_observed"] is False
+        assert restored.history.recent[0]["observation_gap"] is True
+        await hass.async_stop()
+
+    asyncio.run(run())
+
+
+def test_retention_is_bounded():
+    h = SessionHistory()
+    for i in range(60):
+        h.observe({"1": True}, NOW + timedelta(minutes=i))
+        h.observe({"1": False}, NOW + timedelta(minutes=i, seconds=10))
+    assert len(h.recent) == 50

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -1,0 +1,70 @@
+"""Tests for secret-safe integration setup logging."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from homeassistant.const import CONF_HOST
+
+import custom_components.eufy_robomow as integration
+from custom_components.eufy_robomow import cloud
+from custom_components.eufy_robomow.const import (
+    CONF_DEVICE_ID,
+    CONF_EUFY_EMAIL,
+    CONF_EUFY_PASSWORD,
+    CONF_LOCAL_KEY,
+)
+
+
+class _FakeCloudClient:
+    def __init__(self, **kwargs: str) -> None:
+        self.kwargs = kwargs
+
+
+class _FakeCoordinator:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.data: dict[int, object] = {}
+
+    async def async_config_entry_first_refresh(self) -> None:
+        pass
+
+    def async_add_listener(self, _listener):
+        return lambda: None
+
+
+def test_setup_log_does_not_expose_device_id(monkeypatch, caplog, tmp_path: Path) -> None:
+    """The debug setup message must not include the cloud device identifier."""
+    device_id = "sensitive-device-identifier"
+    monkeypatch.setattr(cloud, "EufyCloudClient", _FakeCloudClient)
+    monkeypatch.setattr(integration, "EufyMowerCoordinator", _FakeCoordinator)
+    monkeypatch.setattr(
+        integration, "SessionStore", lambda *args: SimpleNamespace(async_load=AsyncMock())
+    )
+
+    hass = SimpleNamespace(
+        data={},
+        config=SimpleNamespace(path=lambda *parts: str(tmp_path.joinpath(*parts))),
+        config_entries=SimpleNamespace(async_forward_entry_setups=AsyncMock()),
+    )
+    entry = SimpleNamespace(
+        data={
+            CONF_EUFY_EMAIL: "owner@example.invalid",
+            CONF_EUFY_PASSWORD: "not-a-real-password",
+            CONF_DEVICE_ID: device_id,
+            CONF_HOST: "192.0.2.1",
+            CONF_LOCAL_KEY: "not-a-real-local-key",
+        },
+        options={},
+        entry_id="test-entry",
+        async_on_unload=lambda _unsubscribe: None,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=integration.__name__):
+        assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
+
+    assert "Cloud client created" in caplog.text
+    assert device_id not in caplog.text

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,23 @@
+"""Idle omission is distinct from an empty/partial local response."""
+
+from datetime import UTC, datetime, timedelta
+from custom_components.eufy_robomow.telemetry import task_active
+from custom_components.eufy_robomow.sessions import SessionHistory
+
+
+def test_idle_omission_requires_complete_status_shape():
+    assert task_active({"8": 100, "110": 40, "118": 0}) is False
+    assert task_active({}) is None
+    assert task_active({"8": 100}) is None
+    assert task_active({"8": 100, "110": 40, "118": 40}) is None
+    assert task_active({"8": 100, "110": 40, "118": 0, "1": True}) is True
+
+
+def test_observed_idle_then_start_records_a_real_boundary():
+    h = SessionHistory()
+    t = datetime(2026, 9, 6, 10, tzinfo=UTC)
+    h.observe({"8": 100, "110": 40, "118": 0}, t)
+    h.observe({"1": True, "2": False, "118": 0}, t + timedelta(seconds=10))
+    assert h.current["start_observed"] is True
+    h.observe({}, t + timedelta(seconds=20))
+    assert h.current is not None


### PR DESCRIPTION
## Summary

- add an explicit operating mode with `observe_only` as the safe default and `control` as an opt-in;
- add a read-only E15 map image entity with idle and live-mowing rendering;
- add strict map bundle/protobuf validation, atomic private caching, replay protection, per-mode ETags, retry backoff, and script-free SVG rendering;
- add config-flow translations, user documentation, provenance guidance, CI, and focused regression tests.

## Why

The existing integration already provides useful local Tuya control and telemetry, but it has no map support and physical writes are always exposed after setup. This change makes physical control explicit while adding the most visible missing E15 capability as a read-only feature.

The map source is optional. Existing local status and control behavior continue to work without it.

## Safety and compatibility

- New and upgraded entries without an operating-mode option default to `observe_only`.
- Start, pause, dock, and writable setting entities are only exposed after explicit control opt-in.
- Map rendering is read-only; it never supplies coordinates to commands or safety decisions.
- Invalid, future-dated, or older map snapshots are rejected while the latest valid cached map is retained.
- Authentication material, identifiers, raw captures, and private lawn geometry are excluded from the repository and diagnostics.
- This PR claims E15 support only. E18 remains unverified.
- No HACS publication changes and no private P2P acquisition-helper implementation are included.

## Validation

- `ruff check .`
- `pytest`: 52 passed
- options-flow regression verifies saving and automatic reload
- tests cover malformed protobuf/bundles, omitted proto3 zero coordinates, cache permissions, stale snapshots, ETags, retry behavior, pathway preservation, marker bounds, and script-free deterministic SVG output
